### PR TITLE
(RA-1002): Resolved 'end visit' issue  and missing patient id

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/clinicianfacing/VisitsSectionFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/clinicianfacing/VisitsSectionFragmentController.java
@@ -33,6 +33,8 @@ import org.openmrs.ui.framework.page.PageModel;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.openmrs.Location;
+import org.openmrs.module.emrapi.adt.AdtService;
 
 /**
  * Supports the containing PageModel having an "app" property whose config defines a "visitUrl" property
@@ -46,7 +48,7 @@ public class VisitsSectionFragmentController {
 						   UiSessionContext sessionContext,
 						   @SpringBean("appframeworkTemplateFactory") TemplateFactory templateFactory,
                            @SpringBean("coreAppsProperties") CoreAppsProperties coreAppsProperties,
-						   @InjectBeans PatientDomainWrapper patientWrapper) {
+						   @InjectBeans PatientDomainWrapper patientWrapper, @SpringBean("adtService") AdtService adtService) {
 		config.require("patient");
 		Object patient = config.get("patient");
 
@@ -74,8 +76,11 @@ public class VisitsSectionFragmentController {
         if (visitsPageWithSpecificVisitUrl == null) {
             visitsPageWithSpecificVisitUrl = coreAppsProperties.getVisitsPageWithSpecificVisitUrl();
         }
-        if (visitsPageWithSpecificVisitUrl == null) {
-			visitsPageWithSpecificVisitUrl = "coreapps/patientdashboard/patientDashboard.page?patientId={{patient.uuid}}&visitId={{visit.id}}#visits";
+        if (visitsPageUrl == null) {
+			visitsPageUrl = "coreapps/patientdashboard/patientDashboard.page?patientId="+patientWrapper.getPatient().getUuid();
+			Location visitLocation = adtService.getLocationThatSupportsVisits(sessionContext.getSessionLocation());
+                        VisitDomainWrapper activeVisit = adtService.getActiveVisit(patientWrapper.getPatient(), visitLocation);
+			visitsPageUrl += (activeVisit != null) ? "&visitId="+activeVisit.getVisit().getId()+"#visits" : "#visits";
 		}
 		visitsPageWithSpecificVisitUrl = "/" + ui.contextPath() + "/" + visitsPageWithSpecificVisitUrl;
         if (visitsPageUrl == null) {


### PR DESCRIPTION
The 'End Visit' issue on patient dashboard when navigating from the share/edit icon on the clinician facing resolved.

Also, the issue of missing patient id when also navigating from the clinician facing using the share/edit icon in coreapps v 1.10-SNAPSHOT was also resolved.

ticket: https://issues.openmrs.org/browse/RA-1002


**Below is snapshot of working version:**

- On patient clinician facing with active visit:

![clinicianfacing_with_active_visit](https://cloud.githubusercontent.com/assets/10522568/14223678/0963a9fc-f87b-11e5-8488-67068a8ba63d.png)

- Clicking on the share/edit icon from the clinician facing, and then clicking on end visit:
![patient_dashboard](https://cloud.githubusercontent.com/assets/10522568/14223683/26d73256-f87b-11e5-849c-385da1d31275.png)

- After ending visit:
![dashboard2](https://cloud.githubusercontent.com/assets/10522568/14223689/440ec9ce-f87b-11e5-813e-0ae1778efd7a.png)
 
- Clicking on share/edit icon from patient clinician facing without active visit will give you this:
![dashboard2](https://cloud.githubusercontent.com/assets/10522568/14223691/63424f00-f87b-11e5-87a0-c3c65eaaf399.png)


