### PR TITLE
RA-1102 - Added ID to diagnoses list component

### DIFF
--- a/omod/src/main/webapp/fragments/clinicianfacing/diagnosisWidget.gsp
+++ b/omod/src/main/webapp/fragments/clinicianfacing/diagnosisWidget.gsp
@@ -7,7 +7,7 @@
 		<% if (!config.recentDiagnoses) { %>
 		${ ui.message("coreapps.none") }
 		<% } else { %>
-        <ul>
+        <ul id="coreapps-diagnosesList">
             <% config.recentDiagnoses.each { %>
             <li>
             <% if(it.diagnosis.nonCodedAnswer) { %>


### PR DESCRIPTION
This PR adds ID to diagnoses list component is helpful when extracting diagnoses list for testing purposes.
See https://github.com/openmrs/openmrs-distro-referenceapplication/pull/134 comments for details.

TLDR;
By @rkorytkowski 
> You are not allowed to use driver. Replace with List diagnoses = patientDashboardPage.getDiagnoses(); assertThat(diagnoses, contains(...));
getDiagnoses should locate diagnoses using css selector, xpath expression or by id