### PR TITLE
RA-1250: Add multiple extension points in the Patient Header

### DIFF
--- a/omod/src/main/compass/sass/patientHeader.scss
+++ b/omod/src/main/compass/sass/patientHeader.scss
@@ -74,36 +74,6 @@ $green: #51A351;
         top: -15px;
       }
     }
-
-    .colored-message {
-      @include horizontal-list;
-
-      color: white;
-      padding: 2px 4px;
-      border-radius: 1px;
-      margin-top: 4px;
-      font-size: 0.8em;
-    }
-
-    .bordered-colored-message {
-      @extend .colored-message;
-
-      border: 1px solid $darkGray;
-    }
-
-    .active-visit-started-at-message {
-      @extend .bordered-colored-message;
-
-      background: $green;
-      border-color: $green;
-    }
-
-    .active-visit-message {
-      @extend .bordered-colored-message;
-
-      background: $darkGray;
-      border-color: $darkGray;
-    }
   }
 
   .contact-info-label {
@@ -173,6 +143,40 @@ $green: #51A351;
       }
     }
 
+  }
+
+  .colored-message {
+    @include horizontal-list;
+
+    color: white;
+    padding: 2px 4px;
+    border-radius: 1px;
+    margin-top: 4px;
+    font-size: 0.8em;
+  }
+
+  .bordered-colored-message {
+    @extend .colored-message;
+
+    border: 1px solid $darkGray;
+  }
+
+  .active-visit-started-at-message {
+    @extend .bordered-colored-message;
+
+    background: $green;
+    border-color: $green;
+  }
+
+  .active-visit-message {
+    @extend .bordered-colored-message;
+
+    background: $darkGray;
+    border-color: $darkGray;
+  }
+
+  .secondLineFragments {
+    clear: both;
   }
 }
 

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/PatientHeaderFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/PatientHeaderFragmentController.java
@@ -23,6 +23,8 @@ import org.openmrs.PersonName;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appframework.context.AppContextModel;
+import org.openmrs.module.appframework.domain.Extension;
+import org.openmrs.module.appframework.service.AppFrameworkService;
 import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.coreapps.CoreAppsProperties;
 import org.openmrs.module.coreapps.NameSupportCompatibility;
@@ -42,6 +44,7 @@ import org.openmrs.ui.framework.fragment.FragmentConfiguration;
 import org.openmrs.ui.framework.fragment.FragmentModel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +59,7 @@ public class PatientHeaderFragmentController {
                            @SpringBean("coreAppsProperties") CoreAppsProperties coreAppsProperties,
 	                       @SpringBean("baseIdentifierSourceService") IdentifierSourceService identifierSourceService,
                            @FragmentParam(required = false, value="appContextModel") AppContextModel appContextModel,
+                           @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService,
 	                       @FragmentParam("patient") Object patient, @InjectBeans PatientDomainWrapper wrapper,
 	                       @SpringBean("adtService") AdtService adtService, UiSessionContext sessionContext,
                            UiUtils uiUtils,
@@ -69,29 +73,21 @@ public class PatientHeaderFragmentController {
         config.addAttribute("patient", wrapper);
         config.addAttribute("patientNames", getNames(wrapper.getPersonName()));
 
-		VisitDomainWrapper activeVisit = (VisitDomainWrapper) config.getAttribute("activeVisit");
-		if (activeVisit == null) {
-            try {
-                Location visitLocation = adtService.getLocationThatSupportsVisits(sessionContext.getSessionLocation());
-                activeVisit = adtService.getActiveVisit(wrapper.getPatient(), visitLocation);
-            } catch (IllegalArgumentException ex) {
-                // location does not support visits
-            }
-		}
-
         if (appContextModel == null) {
             AppContextModel contextModel = sessionContext.generateAppContextModel();
             contextModel.put("patient", new PatientContextModel(wrapper.getPatient()));
-            contextModel.put("visit", activeVisit == null ? null : new VisitContextModel(activeVisit));
             model.addAttribute("appContextModel", contextModel);
         }
 
-        if (activeVisit != null) {
-            config.addAttribute("activeVisit", activeVisit);
-            config.addAttribute("activeVisitStartDatetime", uiUtils.format(activeVisit.getStartDatetime()));
-        }
+        List<Extension> firstLineFragments = appFrameworkService.getExtensionsForCurrentUser("patientHeader.firstLineFragments");
+        Collections.sort(firstLineFragments);
+        model.addAttribute("firstLineFragments", firstLineFragments);
 		
-		List<ExtraPatientIdentifierType> extraPatientIdentifierTypes = new ArrayList<ExtraPatientIdentifierType>();
+        List<Extension> secondLineFragments = appFrameworkService.getExtensionsForCurrentUser("patientHeader.secondLineFragments");
+        Collections.sort(secondLineFragments);
+        model.addAttribute("secondLineFragments", secondLineFragments);
+
+        List<ExtraPatientIdentifierType> extraPatientIdentifierTypes = new ArrayList<ExtraPatientIdentifierType>();
 
 		for (PatientIdentifierType type : emrApiProperties.getExtraPatientIdentifierTypes()) {
 			List<AutoGenerationOption> options = identifierSourceService.getAutoGenerationOptions(type);

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/patientheader/ActiveVisitStatusFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/patientheader/ActiveVisitStatusFragmentController.java
@@ -1,0 +1,56 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+
+package org.openmrs.module.coreapps.fragment.controller.patientheader;
+
+import org.openmrs.Location;
+import org.openmrs.Patient;
+import org.openmrs.module.appui.UiSessionContext;
+import org.openmrs.module.emrapi.adt.AdtService;
+import org.openmrs.module.emrapi.patient.PatientDomainWrapper;
+import org.openmrs.module.emrapi.visit.VisitDomainWrapper;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.annotation.FragmentParam;
+import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.fragment.FragmentConfiguration;
+import org.openmrs.ui.framework.fragment.FragmentModel;
+
+public class ActiveVisitStatusFragmentController {
+
+	public void controller(FragmentConfiguration config,
+			@FragmentParam("patient") PatientDomainWrapper pdw,
+			@SpringBean("adtService") AdtService adtService,
+			UiSessionContext sessionContext, UiUtils uiUtils, FragmentModel model) {
+
+		model.addAttribute("activeVisitStartDatetime", null);
+
+		Patient patient = pdw.getPatient();
+
+		VisitDomainWrapper activeVisit = (VisitDomainWrapper) config.getAttribute("activeVisit");
+		if (activeVisit == null) {
+			try {
+				Location visitLocation = adtService.getLocationThatSupportsVisits(sessionContext.getSessionLocation());
+				activeVisit = adtService.getActiveVisit(patient, visitLocation);
+			} catch (IllegalArgumentException ex) {
+				// location does not support visits
+			}
+		}
+		if (activeVisit != null) {
+			model.addAttribute("activeVisit", activeVisit);
+			model.addAttribute("activeVisitStartDatetime", uiUtils.format(activeVisit.getStartDatetime()));
+		}
+
+	}
+
+}

--- a/omod/src/main/resources/apps/patientHeader_extension.json
+++ b/omod/src/main/resources/apps/patientHeader_extension.json
@@ -1,0 +1,10 @@
+[
+    {
+        "id": "${project.parent.groupId}.${project.parent.artifactId}.patientHeader.secondLineFragments.activeVisitStatus",
+        "extensionPointId": "patientHeader.secondLineFragments",
+        "extensionParams": {
+            "provider": "${project.parent.artifactId}",
+            "fragment": "patientheader/activeVisitStatus"
+        }
+    }
+]

--- a/omod/src/main/webapp/fragments/patientHeader.gsp
+++ b/omod/src/main/webapp/fragments/patientHeader.gsp
@@ -119,27 +119,18 @@
                     <i class="toggle-icon icon-caret-up small"></i>
                 </a>
             </span>
+
+            <div class="firstLineFragments">
+                <% firstLineFragments.each { %>
+                    ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, [patient: config.patient])}
+                <% } %>
+            </div>
+
             <div class="hidden" id="contactInfoContent" class="contact-info-content">
                 ${ ui.includeFragment("coreapps", "patientdashboard/contactInfoInline", [ patient: config.patient, contextModel: appContextModel ]) }
             </div>
         </h1>
-        <% if (config.activeVisit) { %>
-            <% def visit = config.activeVisit.visit %>
 
-            <div class="active-visit-started-at-message">
-                ${ui.message("coreapps.patientHeader.activeVisit.at", config.activeVisitStartDatetime)}
-            </div>
-            <% if (config.activeVisit.admitted) { %>
-                <div class="active-visit-message">
-                    ${ui.message("coreapps.patientHeader.activeVisit.inpatient", ui.format(config.activeVisit.latestAdtEncounter.location))}
-                </div>
-            <% } else { %>
-                <div class="active-visit-message">
-                    ${ui.message("coreapps.patientHeader.activeVisit.outpatient")}
-                </div>
-            <% } %>
-
-        <% } %>
     </div>
 
     <div class="identifiers">
@@ -191,6 +182,12 @@
             <input type="submit" id="merge-button"
                    value="${ui.message("coreapps.mergePatients.mergeIntoAnotherPatientRecord.button")}"/>
         </form>
+    </div>
+
+    <div class="secondLineFragments">
+        <% secondLineFragments.each { %>
+            ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, [patient: config.patient])}
+        <% } %>
     </div>
 
     <div class="close"></div>

--- a/omod/src/main/webapp/fragments/patientheader/activeVisitStatus.gsp
+++ b/omod/src/main/webapp/fragments/patientheader/activeVisitStatus.gsp
@@ -1,0 +1,17 @@
+<% if (activeVisit) { %>
+    <% def visit = activeVisit.visit %>
+
+    <div class="active-visit-started-at-message">
+        ${ui.message("coreapps.patientHeader.activeVisit.at", activeVisitStartDatetime)}
+    </div>
+    <% if (activeVisit.admitted) { %>
+        <div class="active-visit-message">
+            ${ui.message("coreapps.patientHeader.activeVisit.inpatient", ui.format(activeVisit.latestAdtEncounter.location))}
+        </div>
+    <% } else { %>
+        <div class="active-visit-message">
+            ${ui.message("coreapps.patientHeader.activeVisit.outpatient")}
+        </div>
+    <% } %>
+
+<% } %> 


### PR DESCRIPTION
Create 2 extension points in the Patient Header for easier customization

Extract the current Active Visit status bar and include it using one of the new extension points instead ('secondLineFragment')

Details:
- Modify the Patient Header fragment controller to load the new extensions
- Add CSS declaration for the new extensions layout
- Move the Active Visit status bar style to an uppper level for extensions to use it
- Insert the Groovy code to load the extension points with appropriate config parameters
- Extract the current patient header's Active Visit status bar to an extension with its own controller
