### PR TITLE
RA-1291: Set end date/time for past visits to 23.59.59.000

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/RetrospectiveVisitFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/RetrospectiveVisitFragmentController.java
@@ -44,7 +44,7 @@ public class RetrospectiveVisitFragmentController {
             stopDate = new Date();
         }
         else {
-            stopDate = new DateTime(stopDate).withTime(23, 59, 59, 999).toDate();
+            stopDate = new DateTime(stopDate).withTime(23, 59, 59, 000).toDate();
         }
 
         try {

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/RetrospectiveVisitFragmentControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/RetrospectiveVisitFragmentControllerTest.java
@@ -67,7 +67,7 @@ public class RetrospectiveVisitFragmentControllerTest {
 
         // should round to the time components to the start and end of the days, respectively
         Date expectedStartDate = new DateTime(2012, 1, 1, 0, 0, 0, 0).toDate();
-        Date expectedStopDate = new DateTime(2012, 1, 2, 23, 59, 59, 999).toDate();
+        Date expectedStopDate = new DateTime(2012, 1, 2, 23, 59, 59, 000).toDate();
 
         Visit visit = createVisit();
 
@@ -95,7 +95,7 @@ public class RetrospectiveVisitFragmentControllerTest {
 
         // should round to the time components to the start and end of the days, respectively
         Date expectedStartDate = new DateTime(2012, 1, 1, 0, 0, 0, 0).toDate();
-        Date expectedStopDate = new DateTime(2012, 1, 1, 23, 59, 59, 999).toDate();
+        Date expectedStopDate = new DateTime(2012, 1, 1, 23, 59, 59, 000).toDate();
 
         Visit visit = createVisit();
 
@@ -121,11 +121,11 @@ public class RetrospectiveVisitFragmentControllerTest {
 
         // should round to the time components to the start and end of the days, respectively
         Date expectedStartDate = new DateTime(2012, 1, 1, 0, 0, 0, 0).toDate();
-        Date expectedStopDate = new DateTime(2012, 1, 1, 23, 59, 59, 999).toDate();
+        Date expectedStopDate = new DateTime(2012, 1, 1, 23, 59, 59, 000).toDate();
 
         Visit conflictingVisit = new Visit();
         conflictingVisit.setStartDatetime(new DateTime(2012, 1, 1, 0, 0, 0,0).toDate());
-        conflictingVisit.setStopDatetime(new DateTime(2012, 1, 3, 0, 0, 0, 999).toDate());
+        conflictingVisit.setStopDatetime(new DateTime(2012, 1, 3, 0, 0, 0, 000).toDate());
 
         when(adtService.createRetrospectiveVisit(patient, location, expectedStartDate, expectedStopDate))
                 .thenThrow(ExistingVisitDuringTimePeriodException.class);


### PR DESCRIPTION
Past visit visit have to end at 23.59.59.000 instead of 23.59.59.999 due to a bug in Hibernate 3.6.5-Final
	modified:   omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/RetrospectiveVisitFragmentController.java
Modify Unit test to expect 23.59.59.000 instead of 23.59.59.999
	modified:   omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/RetrospectiveVisitFragmentControllerTest.java