### PR TITLE
RA-1306 Visits By Encounter Type Widget

### DIFF
--- a/omod/src/main/resources/apps/dashboardWidgets_app.json
+++ b/omod/src/main/resources/apps/dashboardWidgets_app.json
@@ -47,5 +47,30 @@
         }
       }
     ]
+  },
+  {
+    "id": "coreapps.visitByEncounterType",
+    "instanceOf": "coreapps.template.dashboardWidget",
+    "description": "coreapps.visitByEncounterType.app.description",
+    "order": 10,
+    "config": {
+      "widget": "visitbyencountertype",
+      "icon": "icon-group",
+      "label": "Recent Visits",
+      "maxRecords": "3",
+      "maxAge": "1d",
+      "combineEncounterTypes": "true"
+    },
+    "extensions": [
+      {
+        "id": "${project.parent.groupId}.${project.parent.artifactId}.mostRecentVitals.clinicianDashboardFirstColumn",
+        "appId": "coreapps.visitByEncounterType",
+        "extensionPointId": "patientDashboard.firstColumnFragments",
+        "extensionParams": {
+          "provider": "${project.parent.artifactId}",
+          "fragment": "dashboardwidgets/dashboardWidget"
+        }
+      }
+    ]
   }
 ]

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardWidgetsCommons.service.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardWidgetsCommons.service.js
@@ -47,7 +47,7 @@ angular.module('dashboardWidgetsCommons', [])
         };
 
         var dateFromMaxAge = function getMaxAgeDate(maxAge) {
-            if(maxAge == undefined)
+            if(angular.isUndefined(maxAge))
                 return null;
 
             var today = new Date();

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardWidgetsCommons.service.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardWidgetsCommons.service.js
@@ -46,10 +46,31 @@ angular.module('dashboardWidgetsCommons', [])
             return days;
         };
 
+        var dateFromMaxAge = function getMaxAgeDate(maxAge) {
+            if(maxAge == undefined)
+                return null;
+
+            var today = new Date();
+            if( maxAge.indexOf('d') !== -1 ){
+                maxAge = maxAge.replace('d', '');
+                today.setDate(today.getDate()-parseInt(maxAge));
+            } else if( maxAge.indexOf('w') !== -1 ){
+                maxAge = maxAge.replace('w', '');
+                today.setDate(today.getDate()-(parseInt(maxAge)*7));
+            } else if( maxAge.indexOf('m') !== -1 ){
+                maxAge = maxAge.replace('m', '');
+                today.setMonth(today.getMonth()-parseInt(maxAge));
+            } else {
+                return null;
+            }
+            return today;
+        };
+
         return {
             dateToDaysAgoMessage: dateToDaysAgoMessage,
             dateToDaysAgo: dateToDaysAgo,
             maxAgeToDays: maxAgeToDays,
+            dateFromMaxAge: dateFromMaxAge
         };
 
     });

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/obsacrossencounters/obsacrossencounters.component.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/obsacrossencounters/obsacrossencounters.component.js
@@ -1,4 +1,4 @@
-angular.module("openmrs-contrib-dashboardwidgets.obsacrossencounters", [ "openmrs-contrib-uicommons" ]).component('obsacrossencounters', {
+angular.module("openmrs-contrib-dashboardwidgets.obsacrossencounters", [ "openmrs-contrib-uicommons", "dashboardWidgetsCommons" ]).component('obsacrossencounters', {
     template: '<div ng-include="getTemplate()">',
     controller: ObsAcrossEncountersController,
     controllerAs: 'ctrl',

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -2,7 +2,7 @@
 var scripts = document.getElementsByTagName("script");
 var obsacrossencountersPath = scripts[scripts.length - 1].src;
 
-function ObsAcrossEncountersController(openmrsRest, $scope) {
+function ObsAcrossEncountersController(openmrsRest, $scope, widgetCommons) {
     var ctrl = this;
 
     ctrl.order = 'desc';
@@ -30,12 +30,20 @@ function ObsAcrossEncountersController(openmrsRest, $scope) {
         openmrsRest.get("encounter", {
                 patient: ctrl.config.patientUuid,
                 v: 'custom:(uuid,encounterDatetime,obs:(uuid,value,concept:(uuid))',
-                limit: ctrl.config.maxRecords,
-                fromdate: getMaxAgeDate(),
+                limit: getMaxRecords(),
+                fromdate: widgetCommons.dateFromMaxAge(ctrl.config.maxAge),
                 order: ctrl.order
             }).then(function (response) {
             getEncounters(response.results);
         });
+    }
+
+    function getMaxRecords() {
+        if(ctrl.config.maxRecords == '' || angular.isUndefined(ctrl.config.maxRecords)){
+            return 4;
+        } else {
+            return ctrl.config.maxRecords;
+        }
     }
 
     function getConfigConceptsAsArray(commaDelimitedConcepts) {
@@ -72,22 +80,6 @@ function ObsAcrossEncountersController(openmrsRest, $scope) {
             }
         }
         return {value: '-'};
-    }
-
-    function getMaxAgeDate() {
-        var today = new Date();
-        var maxAge = ctrl.config.maxAge;
-        if( maxAge.indexOf('d') !== -1 ){
-            maxAge = maxAge.replace('d', '');
-            today.setDate(today.getDate()-parseInt(maxAge));
-        } if( maxAge.indexOf('w') !== -1 ){
-            maxAge = maxAge.replace('w', '');
-            today.setDate(today.getDate()-(parseInt(maxAge)*7));
-        } if( maxAge.indexOf('m') !== -1 ){
-            maxAge = maxAge.replace('m', '');
-            today.setMonth(today.getMonth()-parseInt(maxAge));
-        }
-        return today;
     }
 
     $scope.getTemplate = function () {

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.component.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.component.js
@@ -1,0 +1,8 @@
+angular.module("openmrs-contrib-dashboardwidgets.visitbyencountertype", [ "openmrs-contrib-uicommons", "dashboardWidgetsCommons" ]).component('visitbyencountertype', {
+    template: '<div ng-include="getTemplate()">',
+    controller: VisitByEncounterTypeController,
+    controllerAs: 'ctrl',
+    bindings: {
+        config: '<'
+    }
+});

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
@@ -1,0 +1,68 @@
+//Determine current script path
+var scripts = document.getElementsByTagName("script");
+var visitbyencountertypePath = scripts[scripts.length - 1].src;
+
+function VisitByEncounterTypeController(openmrsRest, $scope, widgetCommons) {
+    var ctrl = this;
+
+    ctrl.visits = [];
+
+    activate();
+
+    function activate() {
+        fetchVisits();
+    }
+
+    function fetchVisits() {
+        openmrsRest.get('visit', {
+            patient: ctrl.config.patientUuid,
+            limit: getMaxRecords(),
+            fromStartDate: widgetCommons.dateFromMaxAge(ctrl.config.maxAge),
+            v: 'custom:(uuid,startDatetime,stopDatetime,encounters:(uuid,encounterType:(uuid,display)))'
+        }).then(function (response) {
+                getVisits(response.results);
+        })
+    }
+
+    function getVisits(visits) {
+        angular.forEach(visits, function (visit) {
+            if(getCombineEncounterTypes()){
+                var vis = {startDatetime: visit.startDatetime, encounterType: ''};
+                angular.forEach(visit.encounters, function (encounter) {
+                    if(vis.encounterType === ''){
+                        vis.encounterType = encounter.encounterType.display;
+                    } else {
+                        vis.encounterType += ', ' + encounter.encounterType.display;
+                    }
+                });
+                ctrl.visits.push(vis);
+            } else {
+                angular.forEach(visit.encounters, function (encounter) {
+                    var vis = {startDatetime: visit.startDatetime};
+                    vis.encounterType = encounter.encounterType.display;
+                    ctrl.visits.push(vis);
+                })
+            }
+        })
+    }
+
+    function getCombineEncounterTypes() {
+        if(ctrl.config.combineEncounterTypes === 'false'){
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    function getMaxRecords() {
+        if(ctrl.config.maxRecords == '' || ctrl.config.maxRecords == null){
+            return 6;
+        } else {
+            return ctrl.config.maxRecords;
+        }
+    }
+
+    $scope.getTemplate = function () {
+        return visitbyencountertypePath.replace(".controller.js", ".html");
+    };
+}

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
@@ -55,7 +55,7 @@ function VisitByEncounterTypeController(openmrsRest, $scope, widgetCommons) {
     }
 
     function getMaxRecords() {
-        if(ctrl.config.maxRecords == '' || ctrl.config.maxRecords == null){
+        if(ctrl.config.maxRecords == '' || angular.isUndefined(ctrl.config.maxRecords)){
             return 6;
         } else {
             return ctrl.config.maxRecords;

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
@@ -1,0 +1,9 @@
+<ul>
+    <li ng-if="ctrl.visits.length != 0" ng-repeat="visit in ctrl.visits track by $index">
+        <a href="/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId={{ctrl.config.patientUuid}}">{{visit.startDatetime | date:'yyyy-MM-dd'}}</a>
+        <div class="tag" ng-if="visit.encounterType !== ''">{{visit.encounterType}}</div>
+    </li>
+    <p ng-if="ctrl.visits.length == 0">
+        None
+    </p>
+</ul>


### PR DESCRIPTION
I wasn't sure what to do if there were no encounterTypes for a visit. See below for my solution. Second thing is that for now clicking the visit date redirects you only to all patient visits not specific one. To make this we need to provide visit and patient id which cannot be done via REST (?) so we would have to modify fragment controller ?

Screen shot
![ra-1306](https://cloud.githubusercontent.com/assets/12660801/23660350/6d7f1cc6-0349-11e7-9908-5f5f071ea6ef.png)