### PR TITLE
RA-1304 - Data Integrity Violations Widget

### DIFF
--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/dataintegrityviolations/dataintegrityviolations.component.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/dataintegrityviolations/dataintegrityviolations.component.js
@@ -1,0 +1,8 @@
+angular.module("openmrs-contrib-dashboardwidgets.dataintegrityviolations", [ "openmrs-contrib-uicommons" ]).component('dataintegrityviolations', {
+    template: '<div ng-include="getTemplate()">',
+    controller: DataIntegrityViolationsController,
+    controllerAs: 'ctrl',
+    bindings: {
+        config: '<'
+    }
+});

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/dataintegrityviolations/dataintegrityviolations.controller.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/dataintegrityviolations/dataintegrityviolations.controller.js
@@ -1,0 +1,27 @@
+//Determine current script path
+var scripts = document.getElementsByTagName("script");
+var dataintegrityviolationstPath = scripts[scripts.length - 1].src;
+
+function DataIntegrityViolationsController($scope, openmrsRest) {
+    $scope.getTemplate = function () {
+        return dataintegrityviolationstPath.replace(".controller.js", ".html");
+    };
+
+    var ctrl = this;
+
+    ctrl.dataViolations = [];
+
+    ctrl.initialize = function () {
+        // Set default maxResults if not defined
+        if (angular.isUndefined(ctrl.config.maxResults)) {
+            ctrl.config.maxResults = 6;
+        }
+        openmrsRest.list('dataintegrity/integrityresults',{patient: ctrl.config.patientUuid, v: 'full', limit: ctrl.config.maxResults}).then(function (resp) {
+            for (let dataViolation of resp.results) {
+                ctrl.dataViolations.push(dataViolation);
+            }
+        })
+    };
+    ctrl.initialize()
+
+}

--- a/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/dataintegrityviolations/dataintegrityviolations.html
+++ b/omod/src/main/webapp/resources/scripts/fragments/dashboardwidgets/dataintegrityviolations/dataintegrityviolations.html
@@ -1,0 +1,17 @@
+<div ng-if="ctrl.dataViolations.length != 0">
+    <ul>
+        <li ng-repeat="dataViolation in ctrl.dataViolations">
+            {{dataViolation.rule.ruleName}}
+            <div class="tag" ng-if="dataViolation.actionUrl">
+                <a style="color: white" href="/openmrs/{{dataViolation.actionUrl}}">
+                    <strong>
+                        Fix
+                    </strong>
+                </a>
+            </div>
+        </li>
+    </ul>
+</div>
+<div ng-if="ctrl.dataViolations.length == 0">
+    None
+</div>


### PR DESCRIPTION
I've used mocked response from future `dataintegrity` REST endpoint to create layout.
Ticket will be ready when endpoint is ready and this app's code is tweaked a bit to fit real-life response.
![ra-1304_mockup](https://cloud.githubusercontent.com/assets/17570611/23794856/b2f5702a-0592-11e7-8a5e-e75787c66a5d.png)
Note: Bold `Fix` labels got their `actionUrl` defined, so it means that they are clickable.
@rkorytkowski @ssmusoke Do you think that way of distinguishing clickable and non-clickable `Fix`es is OK?