### PR TITLE
RA-1342, enable relationships editing in referenceapp

### DIFF
--- a/omod/src/main/resources/apps/dashboardWidgets_app.json
+++ b/omod/src/main/resources/apps/dashboardWidgets_app.json
@@ -107,6 +107,7 @@
       "widget": "relationships",
       "icon": "icon-group",
       "label": "FAMILY",
+      "editPrivilege": "Task: coreapps.editRelationships",
       "maxRecords": "5"
     },
     "extensions": [


### PR DESCRIPTION
Hi @rkorytkowski , here is the config setting that would enable the editing in the reference app. That should help us to debug those errors we see with the new organization of the dashboard widgets. Thanks.