### PR TITLE
RA-1364 Adding width so the background stretches..

### DIFF
--- a/omod/src/main/compass/sass/clinicianfacing/patient.scss
+++ b/omod/src/main/compass/sass/clinicianfacing/patient.scss
@@ -4,4 +4,5 @@
 .float-left {
   float: left;
   clear: left;
+  width: 97.91666%;
 }


### PR DESCRIPTION
... to the container size. Otherwise, the clear:left; fits the background to the text size. Calculated at width: 97.91666%; because the container has a 1.04167% margin on each side.