### PR TITLE
TRUNK-5343: Fix JSON parse error when existingObs is null.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/diagnosis/EncounterDiagnosesFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/diagnosis/EncounterDiagnosesFragmentController.java
@@ -54,7 +54,7 @@ public class EncounterDiagnosesFragmentController {
                 SimpleObject simple = diagnosesFragmentController.simplify(csr, ui, Context.getLocale());
                 jsDiagnosis = simple.toJson();
             }
-            jsForDiagnoses.add("{ diagnosis: diagnoses.CodedOrFreeTextConceptAnswer(" + jsDiagnosis + "), confirmed: " + (d.getCertainty().equals(Diagnosis.Certainty.CONFIRMED)) + ", primary: " + (d.getOrder().equals(Diagnosis.Order.PRIMARY)) + ", existingObs: " + (d.getExistingObs() != null ? d.getExistingObs().getId() : "") + " }");
+            jsForDiagnoses.add("{ diagnosis: diagnoses.CodedOrFreeTextConceptAnswer(" + jsDiagnosis + "), confirmed: " + (d.getCertainty().equals(Diagnosis.Certainty.CONFIRMED)) + ", primary: " + (d.getOrder().equals(Diagnosis.Order.PRIMARY)) + ", existingObs: " + (d.getExistingObs() != null ? d.getExistingObs().getId() : null) + " }");
         }
 
         return jsForDiagnoses;


### PR DESCRIPTION
## Description of what I changed
The PR fixes JSON parse error when existingObs is null. This happens after a visit note was previously saved with a diagnosis.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5343

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [ ] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

