### PR TITLE
RA-1474: Coreapps: Patient Search Widget performed redundant search when running on OpenMRS 2.1.x

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/patientsearch/PatientSearchWidgetFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/patientsearch/PatientSearchWidgetFragmentController.java
@@ -34,9 +34,17 @@ public class PatientSearchWidgetFragmentController {
                            @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService,
                            @FragmentParam(value = "showLastViewedPatients", required = false) Boolean showLastViewedPatients,
                            @FragmentParam(value = "initialSearchFromParameter", required = false) String searchByParam,
-                           @FragmentParam(value = "registrationAppLink", required=false) String registrationAppLink) {
+                           @FragmentParam(value = "registrationAppLink", required=false) String registrationAppLink,
+                           @FragmentParam(value = "searchOnExactIdentifier", required=false) Boolean searchOnExactIdentifier) {
 
         showLastViewedPatients = showLastViewedPatients != null ? showLastViewedPatients : false;
+
+        // Determine version of OpenMRS to modify config parameter "searchOnExactIdentifier"
+        if(Double.valueOf(OpenmrsConstants.OPENMRS_VERSION_SHORT.substring(0,2)) >= 2.1) {
+            model.addAttribute("searchOnExactIdentifier", false);
+        }
+        else
+            model.addAttribute("searchOnExactIdentifier", true);
 
         model.addAttribute("minSearchCharacters",
                 administrationService.getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_MIN_SEARCH_CHARACTERS, "1"));

--- a/omod/src/main/webapp/resources/scripts/patientsearch/patientSearchWidget.js
+++ b/omod/src/main/webapp/resources/scripts/patientsearch/patientSearchWidget.js
@@ -6,7 +6,7 @@ function PatientSearchWidget(configuration){
         clearButtonId: 'patient-search-clear-button',
         dateFormat: 'DD MMM YYYY',
         locale: 'en',
-        defaultLocale: 'en'
+        defaultLocale: 'en',
     };
 
     var config = jq.extend({}, defaults, configuration);
@@ -50,6 +50,7 @@ function PatientSearchWidget(configuration){
     var performingSearch = false;  // flag to check if we are currently updating the search results
     var afterSearchResultsUpdated = [];  // stores a set of functions to execute after we update search results (currently we are only using this for the doEnter function)
     var lastQuery = null;
+    var searchOnExactIdentifier = false;
 
     // set the locale for Moment.js
     // Creole not currently supported by Moment and for some reason it defaults to Japaneses if we don't explicitly set fallback options in the locale() call
@@ -116,7 +117,7 @@ function PatientSearchWidget(configuration){
                     'person:(gender,age,birthdate,birthdateEstimated,personName),' +
                     'attributes:(value,attributeType:(name)))';
 
-    var doSearch = function(query, currRequestCount, autoSelectIfExactIdentifierMatch){
+    var doSearch = function(query, currRequestCount, autoSelectIfExactIdentifierMatch, searchOnExactIdentifier){
 
         // clear out existing search results
         reset();
@@ -131,12 +132,14 @@ function PatientSearchWidget(configuration){
         }
 
         query = jq.trim(query);
-        if (query.indexOf(' ') >= 0) {
+
+        // Add searchOnExactIdentifier to make search calls configurable.
+        // This is for OpenMRS 2.1 > due to inclusion of Lucene.
+        if (query.indexOf(' ') >= 0 || searchOnExactIdentifier === false) {
             searchOnIdentifierAndName(query, currRequestCount);
         }
-        else {
+        else
             searchOnExactIdentifierMatchThenIdentifierAndName(query, currRequestCount, autoSelectIfExactIdentifierMatch);
-        }
     }
 
     // not meant to be called based on entry into the search widget, takes in an array of identifiers: see https://issues.openmrs.org/browse/RA-1404 for potential use cases
@@ -241,7 +244,7 @@ function PatientSearchWidget(configuration){
     var updateSearchResults = function(results){
         var dataRows = [];
         if(results){
-            var results = removeDuplicates(results);
+            results = removeDuplicates(results);
             searchResultsData = searchResultsData.concat(results);
             _.each(results, function(patient) {
                 var birthdate = '';


### PR DESCRIPTION
This pull request is meant to address the issue: RA-1474. The following tasks were accomplished:

- Changed patientSearchWidget.js so that it has a new config parameter: "searchOnExactIdentifier"
- Changed the PatientSearchWidgetFragmentController so that it sets this parameter to true if the current version of OpenMRS is 2.1 or above
- If "searchOnExactIdentifier" = false, then the doSearch method in patientSearchWidget.js should only do a searchOnIdentifierAndName
- Comments were added to PatientSearchWidgetFragmentController and patientSearchWidget.js should be added explaining the reasoning for this (using Lucene in OpenMRS 2.1)