### PR TITLE
TRUNK-5343: Fix the failure to delete an existing diagnosis when adding a new visit note

### DIFF
--- a/api-2.2/src/main/java/org/openmrs/module/coreapps/htmlformentry/EncounterDiagnosesElement.java
+++ b/api-2.2/src/main/java/org/openmrs/module/coreapps/htmlformentry/EncounterDiagnosesElement.java
@@ -281,13 +281,12 @@ public class EncounterDiagnosesElement implements HtmlGeneratorElement, FormSubm
 
             }
 
-            if (formEntrySession.getContext().getMode().equals(FormEntryContext.Mode.EDIT)) {
-                // Remove Diagnoses that were not resubmitted
-                Collection<org.openmrs.Diagnosis> diagnosesToVoid = CollectionUtils
-                        .subtract(existingDiagnoses, resubmittedDiagnoses);
-                for (org.openmrs.Diagnosis diagnosisToVoid : diagnosesToVoid) {
-                    Context.getDiagnosisService().voidDiagnosis(diagnosisToVoid, "Deleted Diagnosis");
-                }
+            // Remove Diagnoses that were not resubmitted
+            Collection<org.openmrs.Diagnosis> diagnosesToVoid = CollectionUtils
+                    .subtract(existingDiagnoses, resubmittedDiagnoses);
+
+            for (org.openmrs.Diagnosis diagnosisToVoid : diagnosesToVoid) {
+                Context.getDiagnosisService().voidDiagnosis(diagnosisToVoid, "Deleted Diagnosis");
             }
         }
         catch (JsonProcessingException ex) {


### PR DESCRIPTION
The PR fixes the failure to delete an existing diagnosis when adding a new visit note.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5343

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [ ] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

