### PR TITLE
RA 1370: Clean up the constraints on the Dashboard widgets to show data within the Reference Application

### DIFF
--- a/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.controller.js
+++ b/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.controller.js
@@ -7,11 +7,12 @@ export default class LatestObsForConceptListController {
 
     $onInit() {
         this.maxConceptCount = 10;
-        this.maxAgeInDays = undefined;
+        this.maxAgeInDays = void 0;
         this.obs = [];
 
         this.openmrsRest.setBaseAppPath("/coreapps");
 
+        // Max age of obs to display
         this.maxAgeInDays = this.widgetsCommons.maxAgeToDays(this.config.maxAge);
 
         // Remove whitespaces
@@ -48,6 +49,12 @@ export default class LatestObsForConceptListController {
                     }
                 }
             });
+
+            if (angular.isDefined(this.maxAgeInDays)) {
+                this.noDataMessage = this.obs.length > 0 ? '' : 'None in the past ' + this.maxAgeInDays + ' days', '';
+            } else {
+                this.noDataMessage = 'None';
+            }            
         }
     }
 }

--- a/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.html
+++ b/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.html
@@ -10,3 +10,4 @@
         </div>
     </li>
 </ul>
+<p ng-if="$ctrl.obs.length == 0">{{$ctrl.noDataMessage}}</p>

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -9,11 +9,20 @@ export default class ObsAcrossEncountersController {
         this.order = 'desc';
         this.concepts = [];
         this.encounters = [];
+        this.maxAgeInDays = void 0;
 
         this.openmrsRest.setBaseAppPath("/coreapps");
 
+        this.maxAgeInDays = this.widgetsCommons.maxAgeToDays(this.config.maxAge);
+
         this.fetchConcepts();
         this.fetchEncounters();
+
+        if (angular.isDefined(this.maxAgeInDays)) {
+            this.noDataMessage = this.encounters.length > 0 ? '' : 'None in the past ' + this.maxAgeInDays + ' days', '';
+        } else {
+            this.noDataMessage = 'None';
+        }
     }
 
     fetchConcepts() {

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
@@ -14,4 +14,4 @@
         </tr>
     </tbody>
 </table>
-<p ng-if="$ctrl.encounters.length == 0">None</p>
+<p ng-if="$ctrl.encounters.length == 0">{{$ctrl.noDataMessage}}</p>

--- a/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.controller.js
@@ -7,7 +7,7 @@ export default class ObsGraphController {
     
     $onInit() {
         // Max age of obs to display
-        this.maxAgeInDays = undefined;
+        this.maxAgeInDays = void 0;
 
         // Concept info
         this.concept = {};
@@ -16,6 +16,9 @@ export default class ObsGraphController {
         this.series = [];
         this.labels = [];
         this.data = [[]];
+
+        // Placeholder message for when no data is present
+        this.noDataMessage = void 0;
 
         this.openmrsRest.setBaseAppPath("/coreapps");
 
@@ -47,5 +50,11 @@ export default class ObsGraphController {
                 }
             }
         })
+
+        if (angular.isDefined(this.maxAgeInDays)) {
+        				this.noDataMessage = this.series.length > 0 ? '' : 'None in the past ' + this.maxAgeInDays + ' days', '';
+        } else {
+        				this.noDataMessage = 'None';
+        }
     }
 }

--- a/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.html
+++ b/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.html
@@ -8,5 +8,5 @@
             chart-series="$ctrl.series"></canvas>
 </div>
 <div ng-if="$ctrl.series.length === 0">
-    None
+    {{$ctrl.noDataMessage}}
 </div>

--- a/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
+++ b/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
@@ -9,10 +9,19 @@ export default class VisitByEncounterTypeController {
         this.visits = [];
         this.serverUrl = "";
 
+        // Placeholder message for when no data is present
+        this.noDataMessage = void 0;
+
+        // Max age of visits to display 
+        this.maxAgeInDays = void 0;
+
         this.openmrsRest.setBaseAppPath("/coreapps");
         this.openmrsRest.getServerUrl().then((result) => {
             this.serverUrl = result;
         });
+
+        // Parse maxAge to day count
+        this.maxAgeInDays = this.widgetsCommons.maxAgeToDays(this.config.maxAge);
 
         //fetchVisits
         this.openmrsRest.get('visit', {
@@ -23,6 +32,12 @@ export default class VisitByEncounterTypeController {
         }).then((response) => {
             this.getVisits(response.results);
         })
+
+        if (angular.isDefined(this.maxAgeInDays)) {
+        	   this.noDataMessage = this.visits.length > 0 ? '' : 'None in the past ' + this.maxAgeInDays + ' days', '';
+        } else {
+        				this.noDataMessage = 'None';
+        }
     }
 
     getVisits(visits) {

--- a/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
+++ b/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
@@ -6,6 +6,6 @@
         <div class="tag" ng-if="visit.encounterType !== ''">{{visit.encounterType}}</div>
     </li>
     <p ng-if="$ctrl.visits.length == 0">
-        None
+        {{$ctrl.noDataMessage}}
     </p>
 </ul>


### PR DESCRIPTION
Addressing this issue: https://issues.openmrs.org/browse/RA-1370

For each of the following widgets:
 1. Latest Obs For Concept List,
 2. Obs Across Encounters,
 3. Obs Graph,
 4. Recent Visit by Encounter Type;

If the maxAge parameter has been set for a widget and no data is available, then instead of just displaying 'None', it should display 'None in the last (time period)'. 

See attached:
![openmrs coreapps widget](https://user-images.githubusercontent.com/1963527/44532982-1ee41180-a6fd-11e8-90df-4129a362039c.png)
