### PR TITLE
RA-1588 Make the Patient summary page responsive.

### DIFF
--- a/omod/src/main/webapp/pages/clinicianfacing/patient.gsp
+++ b/omod/src/main/webapp/pages/clinicianfacing/patient.gsp
@@ -45,7 +45,7 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient.patient, a
 
 
 <div class="clear"></div>
-<div class="container">
+<div class="row">
     <div class="dashboard clear">
         <!-- only show the title div if a title has been defined in the messages.properties -->
         <% if (ui.message(dashboard + ".custom.title") != dashboard + ".custom.title") { %>
@@ -53,7 +53,7 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient.patient, a
             <h3>${ ui.message(dashboard + ".custom.title") }</h3>
         </div>
         <% } %>
-        <div class="info-container column">
+        <div class="col-md-5 col-sm-6 col-xs-12">
             <% if (firstColumnFragments) {
 			    firstColumnFragments.each {
                     // create a base map from the fragmentConfig if it exists, otherwise just create an empty map
@@ -68,7 +68,7 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient.patient, a
 			} %>
 
         </div>
-        <div class="info-container column">
+        <div class="col-md-5 col-sm-6 col-xs-12">
             <% if (secondColumnFragments) {
 			    secondColumnFragments.each {
                     // create a base map from the fragmentConfig if it exists, otherwise just create an empty map
@@ -81,10 +81,9 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient.patient, a
 			        ${ ui.includeFragment(it.extensionParams.provider, it.extensionParams.fragment, configs)}
 			<%   }
 			} %>
-			
         </div>
         <% if ((visitActions && visitActions.size() > 0) || (overallActions && overallActions.size() > 0) || (otherActions && otherActions.size() > 0))  { %>
-            <div class="action-container column">
+            <div class="col-md-2 col-xs-12">
                 <div class="action-section">
                     <% if (activeVisit && visitActions && visitActions.size() > 0) { %>
                         <ul class="float-left">


### PR DESCRIPTION
# Description 

This PR contains changes to make patient summary page responsive with twitter bootstrap.

After changes the page will look like below 

Web Chrome :- 
![49f45cc1cd9bcb83043b84b40cd16c83f108085a_2_690x382](https://user-images.githubusercontent.com/20354461/57648618-469a4300-75c6-11e9-9ca9-be638261048e.png)

iPad 
![b19bc988669563abd01870a9712ed121ec67bcf8_2_690x693](https://user-images.githubusercontent.com/20354461/57648622-4ac66080-75c6-11e9-9720-f356b19f9134.png)

iPhone 5S/SE
![2aa533908fae23752edab4c83c2c3d98df34dcf9](https://user-images.githubusercontent.com/20354461/57648627-50bc4180-75c6-11e9-98ea-3c31de316c26.png)
