### PR TITLE
RA-1589: Observations created with style="textarea" are not displayed with newlines.

### DIFF
--- a/omod/src/main/compass/sass/patientdashboard/patientDashboard.scss
+++ b/omod/src/main/compass/sass/patientdashboard/patientDashboard.scss
@@ -61,6 +61,7 @@ div {
   span, htmlform p {
     color: $highlight;
     font-size: 0.95em;
+    white-space: pre-wrap;
   }
 
   fieldset {


### PR DESCRIPTION
Observations created with style="textarea" are not displayed with newlines.

Add white-space: pre-wrap so that multi-line text observations are displayed with multiple lines (so they appear the same as they did in the textarea when they were created).