### PR TITLE
RA-1622: Respect the value of data-view-url where available

### DIFF
--- a/omod/src/main/webapp/resources/scripts/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.js
@@ -17,12 +17,14 @@ $(function() {
     $(document).on('click', '.editEncounter, .viewEncounter', function(event) {
         var encounterId = $(event.target).attr("data-encounter-id");
         var patientId = $(event.target).attr("data-patient-id");
-        var editUrl = $(event.target).attr("data-edit-url");
+        var actionUrl = $(event.target).attr("data-edit-url") || $(event.target).attr("data-view-url");
         var dataMode = $(event.target).attr("data-mode");
-        if (editUrl) {
-            editUrl = editUrl.replace("{{patientId}}", patientId).replace("{{patient.uuid}}", patientId)
-                .replace("{{encounterId}}", encounterId).replace("{{encounter.id}}", encounterId);
-            emr.navigateTo({ applicationUrl: editUrl });
+        if (actionUrl) {
+            actionUrl = actionUrl.replace(/{{\s?patientId\s?}}/, patientId)
+                .replace(/{{\s?patient.uuid\s?}}/, patientId)
+                .replace(/{{\s?encounterId}\s?}/, encounterId)
+                .replace(/{{\s?encounter.id\s?}}/, encounterId);
+            emr.navigateTo({ applicationUrl: actionUrl });
         } else {
             if ("view" == dataMode) {
             	emr.navigateTo({


### PR DESCRIPTION
JIRA: https://issues.openmrs.org/browse/RA-1622

When using a non-htmlformentry form, the patient dashboard generates "viewEncounter" and "editEncounter" links using the extension configuration to store the URL in the data-view-url or data-edit-url form as appropriate. Unfortunately, the click handler in defaultEncounterTemplate.js only handles a url stored in the data-edit-url form, resulting in an error when the view link is clicked.