### PR TITLE
RA-1623:Encounter type name localisation

### DIFF
--- a/omod/src/main/web/dashboardwidgets/visitbyencountertype/index.js
+++ b/omod/src/main/web/dashboardwidgets/visitbyencountertype/index.js
@@ -1,9 +1,10 @@
 import angular from 'angular';
 import openmrsApi from '@openmrs/angularjs-openmrs-api';
 import commons from './../dashboardwidgets.services';
+import openmrsTranslate from '@openmrs/angularjs-openmrs-api';
 
 import { VisitByEncounterTypeComponent } from './visitbyencountertype.component';
 
 
-export default angular.module("openmrs-contrib-dashboardwidgets.visitbyencountertype", [ openmrsApi, commons ])
+export default angular.module("openmrs-contrib-dashboardwidgets.visitbyencountertype", [ openmrsApi, commons , openmrsTranslate])
 	.component(VisitByEncounterTypeComponent.selector, VisitByEncounterTypeComponent).name;

--- a/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
+++ b/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
@@ -1,8 +1,8 @@
 export default class VisitByEncounterTypeController {
-    constructor(openmrsRest, widgetsCommons) {
+    constructor(openmrsRest, widgetsCommons , openmrsTranslate) {
         'ngInject';
 
-        Object.assign(this, {openmrsRest, widgetsCommons});
+        Object.assign(this, {openmrsRest, widgetsCommons , openmrsTranslate});
     }
 
     $onInit() {

--- a/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
+++ b/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
@@ -3,7 +3,7 @@
         <a href="{{$ctrl.serverUrl}}/coreapps/patientdashboard/patientDashboard.page?patientId={{$ctrl.config.patientUuid}}&visitId={{visit.uuid}}">
             {{visit.startDatetime | date: $ctrl.config.dateFormat}}
         </a>
-        <div class="tag" ng-if="visit.encounterType !== ''">{{visit.encounterType}}</div>
+        <div class="tag" ng-if="visit.encounterType !== ''">{{visit.encounterType | translate }}</div>
     </li>
     <p ng-if="$ctrl.visits.length == 0">
         None


### PR DESCRIPTION
RA-1623:Encounter type name localisation in recent visit
Translate the encounter type name based on the locale in recent visit section of patient dashboard (coreapps).You need to store encounter type name in the form of key and their value in messages.properties.

Files which are modified are:

openmrs-module-coreapps/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.html
openmrs-module-coreapps/omod/src/main/web/dashboardwidgets/visitbyencountertype/visitbyencountertype.controller.js
openmrs-module-coreapps/omod/src/main/web/dashboardwidgets/visitbyencountertype/index.js 