### PR TITLE
RA-1640: Localizing link titles in custom links widget.

### DIFF
--- a/omod/src/main/webapp/fragments/dashboardwidgets/customLinksWidget.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/customLinksWidget.gsp
@@ -6,7 +6,7 @@
     <div class="info-body">
         <ul>
             <% config.links.each { title, link -> %>
-            <li><a href="${link}">${title}</a> </li>
+            <li><a href="${link}">${ui.message(title)}</a> </li>
             <% } %>
         </ul>
     </div>


### PR DESCRIPTION
Translating link titles in custom links widget.
[Link to card](https://issues.openmrs.org/browse/RA-1640)