### PR TITLE
RA-1696:Switch from 'success()' to 'done()' and 'error()' to 'fail()' in JQuery 3.4.1

### DIFF
--- a/omod/src/main/webapp/resources/scripts/custom/visits.js
+++ b/omod/src/main/webapp/resources/scripts/custom/visits.js
@@ -131,7 +131,7 @@ visit.showEditVisitDateDialog = function(visitId) {
             actions: {
                 confirm: function() {
                     var url = emr.fragmentActionLink("coreapps", "visit/visitDates", "setDuration");
-                    $.getJSON(url, $('#edit-visit-dates-dialog-form-' + visitId).serialize()).success(function(data) {
+                    $.getJSON(url, $('#edit-visit-dates-dialog-form-' + visitId).serialize()).done(function(data) {
                             if (data.success) {
                                 jq('#edit-visit-dates-dialog-form-' + visitId + ' .icon-spin').css('display', 'inline-block').parent().addClass('disabled');
                                 // TODO Do we need to update this to specify return url, or is this link only going  to ever be used from the old visits view? 
@@ -201,7 +201,7 @@ visit.showEditVisitDialog = function(visitId) {
             confirm: function() {
                 if(visitId !== undefined){
                     var url = emr.fragmentActionLink("coreapps", "visit/quickVisit", "update");
-                    jq.getJSON(url, visit.buildVisitTypeAttributeParams(visitId)).success(function(data) {
+                    jq.getJSON(url, visit.buildVisitTypeAttributeParams(visitId)).done(function(data) {
                             if(data.success) {
                                 jq('#edit-visit-dialog-form-' + visitId + ' .icon-spin').css('display', 'inline-block').parent().addClass('disabled');
                                 window.location.reload();

--- a/omod/src/main/webapp/resources/scripts/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.js
@@ -52,9 +52,9 @@ $(function() {
 	    		if(encounterDetailsSection.html() == "") { encounterDetailsSection.html("<i class=\"icon-spinner icon-spin icon-2x pull-left\"></i>");}
 	    jq.getJSON(
 	        		emr.fragmentActionLink("htmlformentryui", "htmlform/viewEncounterWithHtmlForm", "getAsHtml", { encounterId: id })
-	        ).success(function(data){
+	        ).done(function(data){
 	            encounterDetailsSection.html(data.html);
-	        }).error(function(err){
+	        }).fail(function(err){
 	            emr.errorAlert(err);
 	        });
 	    } else {
@@ -68,9 +68,9 @@ $(function() {
 	    		if(encounterDetailsSection.html() == "") { encounterDetailsSection.html("<i class=\"icon-spinner icon-spin icon-2x pull-left\"></i>");}
 	        jq.getJSON(
 	            emr.fragmentActionLink("coreapps", "visit/visitDetails", "getEncounterDetails", { encounterId: id })
-	        ).success(function(data){
+	        ).done(function(data){
 	            encounterDetailsSection.html(displayTemplate(data));
-	        }).error(function(err){
+	        }).fail(function(err){
 	            emr.errorAlert(err);
 	        });
 	    }

--- a/omod/src/main/webapp/resources/scripts/fragments/visitDetails.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/visitDetails.js
@@ -10,7 +10,7 @@ function loadTemplates (visitId, patientId, fromEncounter, encounterCount, curre
                 encounterCount: encounterCount,
                 userId: currentUserId
             })
-            ).success(function(data) {
+            ).done(function(data) {
                 $('.viewVisitDetails').removeClass('selected');
                 visitElement.addClass('selected');
                 visitDetailsSection.html(visitDetailsTemplate(data));
@@ -63,7 +63,7 @@ function loadTemplates (visitId, patientId, fromEncounter, encounterCount, curre
                     });
                 }
                 
-            }).error(function(err) {
+            }).fail(function(err) {
                 emr.errorMessage(err);
             });
         }


### PR DESCRIPTION
Made the change because in JQuery 3.4.1 the ajax successful call back is done() after deprecation of success() and fail() with deprecation of error() as the error call back function
https://issues.openmrs.org/browse/RA-1696