### PR TITLE
HTML-718, gray out retired concepts

### DIFF
--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -76,6 +76,14 @@ export default class ObsAcrossEncountersController {
     }
   }
 
+  isRetired(obs) {
+    let retired = false;
+    if (obs && angular.isDefined(obs.value) && angular.isDefined(obs.value.retired)) {
+      retired = obs.value.retired;
+    }
+    return retired;
+  }
+
   displayObs(obs) {
     let display = "";
     if (obs.value != null) {
@@ -203,7 +211,7 @@ export default class ObsAcrossEncountersController {
               let shortDisplay = this.getConceptWithShortName(concept);
               obs.value.display = shortDisplay.display;
             }, function (err) {
-              console.log(`failed to retrieve ${conceptUuid}, error: ${err}`);
+              console.log(`failed to retrieve concept ${conceptUuid}, ${err}`);
             });
           }
         }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
@@ -11,6 +11,11 @@
         word-wrap: break-word;
     }
 
+    .retiredConcept {
+        color: gray;
+        font-style: italic;
+    }
+
     ::-webkit-scrollbar {
         -webkit-appearance: none;
         height: 5px;
@@ -37,7 +42,7 @@
     <tbody>
         <tr ng-repeat="encounter in $ctrl.simpleEncs| orderBy: '-encounterDatetime'">
             <th>{{encounter.encounterDatetime | date: $ctrl.config.dateFormat}}</th>
-            <th ng-repeat="(key,value) in $ctrl.conceptsMap">
+            <th ng-repeat="(key,value) in $ctrl.conceptsMap" ng-class="($ctrl.isRetired(encounter.obs[key])) ? 'retiredConcept' : ''">
                 {{ encounter.obs[key] ? $ctrl.displayObs(encounter.obs[key]) : '' }}
             </th>
         </tr>


### PR DESCRIPTION
@mogoodrich , I think this is for the obscrossacounters widget to display retired concepts as grayed-out similar to the htmlform autocomplete widget. Thanks for reviewing it.