### PR TITLE
RA-1762: 'editStyle' config support for defaultEncounterTemplate.

### DIFF
--- a/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
@@ -43,8 +43,8 @@
 
 	<span>
         {{ if ( (config.editable == null || config.editable) && encounter.canEdit) { }}
-            <i class="viewEncounter view-action icon-file-alt" data-mode="view" data-patient-id="{{- patient.id }}" data-encounter-id="{{- encounter.encounterId }}" {{ if (config.viewUrl) { }} data-view-url="{{- config.viewUrl }}" {{ } }} title="${ ui.message("coreapps.view") }"></i>
-            <i class="editEncounter edit-action icon-pencil" data-patient-id="{{- patient.id }}" data-encounter-id="{{- encounter.encounterId }}" {{ if (config.editUrl) { }} data-edit-url="{{- config.editUrl }}" {{ } }} title="${ ui.message("coreapps.edit") }"></i>
+            <i class="viewEncounter view-action icon-file-alt" data-mode="view" data-patient-id="{{- patient.id }}" data-encounter-id="{{- encounter.encounterId }}" {{ if (config.viewUrl) { }} data-view-url="{{- config.viewUrl }}" {{ } }} {{ if (config.uiStyle) { }} data-ui-style="{{- config.uiStyle }}" {{ } }} title="${ ui.message("coreapps.view") }"></i>
+            <i class="editEncounter edit-action icon-pencil" data-patient-id="{{- patient.id }}" data-encounter-id="{{- encounter.encounterId }}" {{ if (config.editUrl) { }} data-edit-url="{{- config.editUrl }}" {{ } }} {{ if (config.uiStyle) { }} data-ui-style="{{- config.uiStyle }}" {{ } }} title="${ ui.message("coreapps.edit") }"></i>
         {{ } }}
         {{ if ( encounter.canDelete ) { }}
 	       <i class="deleteEncounterId delete-action icon-remove" data-visit-id="{{- encounter.visitId }}" data-encounter-id="{{- encounter.encounterId }}" title="${ ui.message("coreapps.delete") }"></i>

--- a/omod/src/main/webapp/resources/scripts/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.js
+++ b/omod/src/main/webapp/resources/scripts/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.js
@@ -1,4 +1,5 @@
 $(function() {
+	const defaultUiStyle = 'Standard'; //default UI style.
 	$(document).on('click','.view-details.collapsed', function(event){
         var jqTarget = $(event.currentTarget);
         var encounterId = jqTarget.data("encounter-id");
@@ -19,6 +20,7 @@ $(function() {
         var patientId = $(event.target).attr("data-patient-id");
         var actionUrl = $(event.target).attr("data-edit-url") || $(event.target).attr("data-view-url");
         var dataMode = $(event.target).attr("data-mode");
+        var uiStyle = getUiStyle(event.target);
         if (actionUrl) {
             actionUrl = actionUrl.replace(/{{\s?patientId\s?}}/, patientId)
                 .replace(/{{\s?patient.uuid\s?}}/, patientId)
@@ -26,16 +28,17 @@ $(function() {
                 .replace(/{{\s?encounter.id\s?}}/, encounterId);
             emr.navigateTo({ applicationUrl: actionUrl });
         } else {
+			//editStyle is a parameter supported by viewEncounterHtmlForm. Refer => openmrs-module-htmlformentryui: org.openmrs.module.htmlformentryui.page.controller.htmlform.ViewEncounterWithHtmlFormPageController#get
             if ("view" == dataMode) {
             	emr.navigateTo({
 	                provider: "htmlformentryui",
 	                page: "htmlform/viewEncounterWithHtmlForm",
-	                query: { patient: patientId, encounter: encounterId}
+	                query: { patient: patientId, encounter: encounterId, editStyle: uiStyle}
 	            });
             } else {
             	emr.navigateTo({
 	                provider: "htmlformentryui",
-	                page: "htmlform/editHtmlFormWithStandardUi",
+	                page: "htmlform/editHtmlFormWith" + uiStyle + "Ui",
 	                query: { patientId: patientId, encounterId: encounterId }
 	            });
             }
@@ -76,5 +79,14 @@ $(function() {
 	            emr.errorAlert(err);
 	        });
 	    }
+	}
+
+	//Returns the UI style from the element with first letter uppercase and with the rest lower case
+	function getUiStyle(elem){
+		var uiStyle = $(elem).attr("data-ui-style");
+		if(uiStyle && uiStyle != null){
+			return uiStyle[0].toUpperCase() + uiStyle.substring(1).trim().toLowerCase();
+		}
+		return defaultUiStyle; 
 	}
 });


### PR DESCRIPTION
## RA-1762 Edit Style configuration support for defaultEncounterTemplate in Patient Dashboard
## Description of what I changed
Added support to read editStyle from Fragment Configuration to make switch between edit styles(currently Standard and Simple). This will be used in handling edit and view button in **defaultEncounterTemplate** and edit button in View mode by passing the editStyle as a query parameter in **viewEncounterWithHtmlForm** controller

## Issue I worked on
see https://issues.openmrs.org/browse/RA-1762

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`