### PR TITLE
Refactor obsacrossencounters controller; add useConceptNameForValue config option

### DIFF
--- a/omod/src/main/web/dashboardwidgets/dashboardwidgetscommons.service.js
+++ b/omod/src/main/web/dashboardwidgets/dashboardwidgetscommons.service.js
@@ -123,7 +123,7 @@ export default class WidgetsCommons {
     }
 
     isDrug(obj) {
-        return !!obj.concept
+        return Boolean(obj.concept);
     }
 
 }

--- a/omod/src/main/web/dashboardwidgets/dashboardwidgetscommons.service.js
+++ b/omod/src/main/web/dashboardwidgets/dashboardwidgetscommons.service.js
@@ -93,6 +93,7 @@ export default class WidgetsCommons {
      * 
      * @param {object} concept Must have rep including `display,names:(voided,locale,conceptNameType,localePreferred,name)`
      * @param {string} nameType One of "FSN", "shortName", "preferred"
+     * @param {string} locale The preferred locale
      */
     getConceptName(concept, nameType, locale) {
         const names = concept.names.filter(n => !n.voided && n.locale === locale);
@@ -110,4 +111,19 @@ export default class WidgetsCommons {
         }
         return resultName ? resultName.name : concept.display;
     }
+
+    hasDatatypeDateOrSimilar(concept) {
+        return ['8d4a505e-c2cc-11de-8d13-0010c6dffd0f',
+            '8d4a591e-c2cc-11de-8d13-0010c6dffd0f',
+            '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].includes(concept.datatype.uuid)
+    }
+
+    hasDatatypeCoded(concept) {
+        return concept.datatype.uuid === "8d4a48b6-c2cc-11de-8d13-0010c6dffd0f";
+    }
+
+    isDrug(obj) {
+        return !!obj.concept
+    }
+
 }

--- a/omod/src/main/web/dashboardwidgets/dashboardwidgetscommons.service.js
+++ b/omod/src/main/web/dashboardwidgets/dashboardwidgetscommons.service.js
@@ -1,90 +1,113 @@
 export default class WidgetsCommons {
 
-        // Method used to define days since given date and return it as message
-        dateToDaysAgoMessage(date) {
-            let days = this.dateToDaysAgo(date);
+    // Method used to define days since given date and return it as message
+    dateToDaysAgoMessage(date) {
+        let days = this.dateToDaysAgo(date);
 
-            if (days == 0) {
-                return "today"
-            }
-            else if (days == 1) {
-                return days + " day ago"
-            }
-            else {
-                return days + " days ago"
-            }
-        };
+        if (days == 0) {
+            return "today"
+        }
+        else if (days == 1) {
+            return days + " day ago"
+        }
+        else {
+            return days + " days ago"
+        }
+    };
 
-        //Number of days since the given date
-        daysSinceDate(date) {
+    //Number of days since the given date
+    daysSinceDate(date) {
+        let days = 0;
+        if (date !== null) {
+            let givenDate = new Date(date).setHours(0,0,0,0);
+            let today = new Date().setHours(0,0,0,0);
+            let seconds = Math.floor((today - givenDate) / 1000);
+            days = Math.floor(seconds / 86400);
+        }
+
+        return days;
+    };
+
+    // Method used to define days since given date
+    dateToDaysAgo(date) {
+        const time = new Date(date).getTime();
+        const seconds = Math.floor((new Date().getTime() - time) / 1000);
+        const interval = Math.floor(seconds / 86400);
+        let days = 0;
+        if (interval > 1) {
+            days = interval;
+        }
+        return days;
+    };
+
+    // Method used to parse maxAge to day count
+    maxAgeToDays(maxAge) {
+        if (typeof maxAge === 'undefined') {
+            return undefined;
+        } else {
             let days = 0;
-            if (date !== null) {
-              let givenDate = new Date(date).setHours(0,0,0,0);
-              let today = new Date().setHours(0,0,0,0);
-              let seconds = Math.floor((today - givenDate) / 1000);
-              days = Math.floor(seconds / 86400);
-            }
-
-            return days;
-        };
-
-        // Method used to define days since given date
-        dateToDaysAgo(date) {
-            const time = new Date(date).getTime();
-            const seconds = Math.floor((new Date().getTime() - time) / 1000);
-            const interval = Math.floor(seconds / 86400);
-            let days = 0;
-            if (interval > 1) {
-                days = interval;
-            }
-            return days;
-        };
-
-        // Method used to parse maxAge to day count
-        maxAgeToDays(maxAge) {
-            if (typeof maxAge === 'undefined') {
-                return undefined;
-            } else {
-                let days = 0;
-                const values = maxAge.split(" ");
-                for (const value of values) {
-                    if (value.includes("d")) {
-                        days += parseInt(value.replace("d", ""));
-                    }
-                    if (value.includes("w")) {
-                        days += parseInt(value.replace("w", "")) * 7;
-                    }
-                    if (value.includes("m")) {
-                        days += parseInt(value.replace("m", "")) * 30;
-                    }
-                    if (value.includes("y")) {
-                        days += parseInt(value.replace("y", "")) * 365;
-                    }
+            const values = maxAge.split(" ");
+            for (const value of values) {
+                if (value.includes("d")) {
+                    days += parseInt(value.replace("d", ""));
                 }
-                return days;
+                if (value.includes("w")) {
+                    days += parseInt(value.replace("w", "")) * 7;
+                }
+                if (value.includes("m")) {
+                    days += parseInt(value.replace("m", "")) * 30;
+                }
+                if (value.includes("y")) {
+                    days += parseInt(value.replace("y", "")) * 365;
+                }
             }
-        };
+            return days;
+        }
+    };
 
-        maxAgeToDate(maxAge) {
-            if(typeof maxAge === 'undefined')
-                return null;
+    maxAgeToDate(maxAge) {
+        if(typeof maxAge === 'undefined')
+            return null;
 
-            var today = new Date();
-            if( maxAge.indexOf('d') !== -1 ){
-                maxAge = maxAge.replace('d', '');
-                today.setDate(today.getDate()-parseInt(maxAge));
-            } else if( maxAge.indexOf('w') !== -1 ){
-                maxAge = maxAge.replace('w', '');
-                today.setDate(today.getDate()-(parseInt(maxAge)*7));
-            } else if( maxAge.indexOf('m') !== -1 ){
-                maxAge = maxAge.replace('m', '');
-                today.setMonth(today.getMonth()-parseInt(maxAge));
-            } else if( maxAge.indexOf('y') !== -1 ){
-                maxAge = maxAge.replace('y', '');
-                today.setDate(today.getYear()-(parseInt(maxAge)));
-            } else {
-                return null;
-            }
-            return today;
-        };
+        var today = new Date();
+        if( maxAge.indexOf('d') !== -1 ){
+            maxAge = maxAge.replace('d', '');
+            today.setDate(today.getDate()-parseInt(maxAge));
+        } else if( maxAge.indexOf('w') !== -1 ){
+            maxAge = maxAge.replace('w', '');
+            today.setDate(today.getDate()-(parseInt(maxAge)*7));
+        } else if( maxAge.indexOf('m') !== -1 ){
+            maxAge = maxAge.replace('m', '');
+            today.setMonth(today.getMonth()-parseInt(maxAge));
+        } else if( maxAge.indexOf('y') !== -1 ){
+            maxAge = maxAge.replace('y', '');
+            today.setDate(today.getYear()-(parseInt(maxAge)));
+        } else {
+            return null;
+        }
+        return today;
+    };
+
+    /**
+     * Returns the most appropriate name given a concept and a name type preference
+     * 
+     * @param {object} concept Must have rep including `display,names:(voided,locale,conceptNameType,localePreferred,name)`
+     * @param {string} nameType One of "FSN", "shortName", "preferred"
+     */
+    getConceptName(concept, nameType, locale) {
+        const names = concept.names.filter(n => !n.voided && n.locale === locale);
+        const fsn = names.filter(n => n.conceptNameType === "FULLY_SPECIFIED")[0];
+        const short = names.filter(n => n.conceptNameType === "SHORT")[0];
+        const shortEn = concept.names.filter(n => !n.voided && n.locale === 'en' && n.conceptNameType === "SHORT")[0];
+        const preferred = names.filter(n => n.localePreferred)[0];
+        let resultName;
+        if (nameType === "FSN") {
+            resultName = fsn || preferred;
+        } else if (nameType === "shortName") {
+            resultName = short || shortEn;
+        } else if (nameType === "preferred") {
+            resultName = preferred;
+        }
+        return resultName ? resultName.name : concept.display;
+    }
 }

--- a/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.controller.js
+++ b/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.controller.js
@@ -48,11 +48,11 @@ export default class LatestObsForConceptListController {
             '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].includes(obs.concept.datatype.uuid)) {
             // If value is date, time or datetime
             return this.$filter('date')(new Date(obs.value), this.config.dateFormat);
-        } else if (angular.isDefined(obs.value.display)) {
+        } else if (obs.value.concept) {
             // If value is a concept
              return this.widgetsCommons.getConceptName(obs.value, this.config.conceptNameType, this.config.locale);
         } else {
-            return obs.value;
+            return obs.value.display || obs.value;
         }
     }
 }

--- a/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.controller.js
+++ b/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.controller.js
@@ -43,14 +43,10 @@ export default class LatestObsForConceptListController {
     }
 
     getObsValue(obs) {
-        if (['8d4a505e-c2cc-11de-8d13-0010c6dffd0f',
-            '8d4a591e-c2cc-11de-8d13-0010c6dffd0f',
-            '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].includes(obs.concept.datatype.uuid)) {
-            // If value is date, time or datetime
+        if (this.widgetsCommons.hasDatatypeDateOrSimilar(obs.concept)) {
             return this.$filter('date')(new Date(obs.value), this.config.dateFormat);
-        } else if (obs.value.concept) {
-            // If value is a concept
-             return this.widgetsCommons.getConceptName(obs.value, this.config.conceptNameType, this.config.locale);
+        } else if (this.widgetsCommons.hasDatatypeCoded(obs.concept)) {
+            return this.widgetsCommons.getConceptName(obs.value, this.config.conceptNameType, this.config.locale);
         } else {
             return obs.value.display || obs.value;
         }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -85,11 +85,11 @@ export default class ObsAcrossEncountersController {
         '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].includes(obs.concept.datatype.uuid)) {
         // If value is date, time or datetime
         return this.$filter('date')(new Date(obs.value), this.config.dateFormat);
-    } else if (angular.isDefined(obs.value.display)) {
+    } else if (obs.value.concept) {
         // If value is a concept
         return this.config.useConceptNameForValue ? obs.value.concept.display : obs.value.display
     } else {
-        return obs.value;
+        return obs.value.display || obs.value;
     }
   }
 

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -128,26 +128,26 @@ export default class ObsAcrossEncountersController {
   }
 
   /**
-   * Iterates through all obs, and for all value coded,
-   * replace the default obs.value.display with
-   * the value display of the appropriate shortName
+   * Sets all obs coded concept values and drug value concepts to use the short name
    * @param encounters
    */
   updateWithConceptShortNames(encounters) {
     for (let encounter of encounters) {
       for (let obs of encounter.obs) {
-        // if the obs value is coded then we try to look for the short names of the coded answers
-        // some obs.value nodes contain the concept property that points to the concept
-        // and other coded obs(e.g. Drug Frequency) do not contain a child concept property
-        const conceptUuid = obs.value.concept ? obs.value.concept.uuid : obs.value.uuid;
-        if (conceptUuid) {
-          this.openmrsRest.get("concept/" + conceptUuid, {
-            v: this.CONCEPT_CUSTOM_REP
-          }).then((concept) => {
-            obs.value.display = this.widgetsCommons.getConceptName(concept, "shortName", this.sessionLocale);
-          }).catch(err => console.error(`failed to retrieve concept ${conceptUuid}, ${err}`));
+        if (this.widgetsCommons.isDrug(obs.value)) {
+          this.updateWithShortName(obs.value.concept);
+        } else if (this.widgetsCommons.hasDatatypeCoded(obs.concept)) {
+          this.updateWithShortName(obs.value);
         }
       }
     }
+  }
+
+  updateWithShortName(concept) {
+    this.openmrsRest.get("concept/" + concept.uuid, {
+      v: this.CONCEPT_CUSTOM_REP
+    }).then((concept) => {
+      concept.display = this.widgetsCommons.getConceptName(concept, "shortName", this.sessionLocale);
+    }).catch(err => console.error(`failed to retrieve concept ${conceptUuid}, ${err}`));
   }
 }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -8,9 +8,8 @@ export default class ObsAcrossEncountersController {
   $onInit() {
     this.order = 'desc';
     this.sessionLocale = null;
-    this.CONCEPT_CUSTOM_REP = 'custom:(uuid,display,names:(display,conceptNameType,locale)';
+    this.CONCEPT_CUSTOM_REP = 'custom:(uuid,display,names:(voided,locale,conceptNameType,localePreferred,name)';
 
-    this.concepts = [];
     // a map of conceptUUID --> concept(REST response)
     this.conceptsMap = {};
     this.simpleEncs = [];
@@ -29,177 +28,107 @@ export default class ObsAcrossEncountersController {
     }).then((session) => {
       this.sessionLocale = session.locale;
     }, function(error) {
-       console.log(`failed to retrieve session info, error: ${error}`)
+       console.error(`failed to retrieve session info, error: ${error}`)
     });
   }
+  
   fetchHeaders() {
-    if (this.config.headers && this.config.headers.length > 0) {
+    if (this.config.headers) {
       let columnNames = this.config.headers.split(",");
-      if (columnNames !== null && columnNames.length > 0) {
-        this.headers = columnNames;
-      }
+      this.headers = columnNames;
     }
   }
 
   fetchConcepts() {
-    this.concepts = this.getConfigConceptsAsArray(this.config.concepts);
-    for (let i = 0; i < this.concepts.length; i++) {
-      this.openmrsRest.get("concept/" + this.concepts[i], {
+    let conceptKeys = this.config.concepts.split(",").map(c => c.trim());
+    for (let i = 0; i < conceptKeys.length; i++) {
+      this.openmrsRest.get("concept/" + conceptKeys[i], {
         v: this.CONCEPT_CUSTOM_REP
       }).then((concept) => {
-        let index = this.concepts.indexOf(concept.uuid);
-        this.concepts[index] = this.getConceptWithShortName(concept);
         // update the concept map with the REST representation of the concept
-        this.conceptsMap[concept.uuid] = this.getConceptWithShortName(concept);
+        concept.display = this.widgetsCommons.getConceptName(concept, "shortName", this.sessionLocale);
+        this.conceptsMap[concept.uuid] = concept;
       });
     }
   }
 
   fetchEncounters() {
-    let promises = [];
-    // merge encounterType with encounterTypes if both exist
-    if (this.config.encounterType) {
-      this.config.encounterTypes += this.config.encounterTypes ? ',' + this.config.encounterType : this.config.encounterType;
-    }
-    let encounterTypes = this.config.encounterTypes ? this.config.encounterTypes.replace(' ', '').split(',') : [null];
-    if (encounterTypes !== null && encounterTypes.length > 0) {
-      for (let i = 0; i < encounterTypes.length; i++) {
-        let promisedEncounter = this.openmrsRest.get("encounter", {
-          patient: this.config.patientUuid,
-          encounterType: encounterTypes[i] ? encounterTypes[i]: null,
-          v: 'custom:(uuid,encounterDatetime,encounterType:(name,description),obs:(id,uuid,value,concept:(id,uuid,name:(display),datatype:(uuid)),groupMembers:(id,uuid,display,value,concept:(id,uuid,name:(display),datatype:(uuid))))',
-          limit: this.getMaxRecords(),
-          fromdate: this.widgetsCommons.maxAgeToDate(this.config.maxAge),
-          order: this.order
-        }).then((response) => {
-          return response.results;
-        });
-        promises.push(promisedEncounter);
+    const encounterTypes = this.config.encounterTypes ? this.config.encounterType.split(',').map(c => c.trim()) : [];
+    const legacyEncounterTypes = this.config.encounterType ? this.config.encounterType.split(',').map(c => c.trim()) : [];
+    encounterTypes.push(...legacyEncounterTypes);
+    
+    const encounterPromises = encounterTypes.map(e =>
+      this.openmrsRest.get("encounter", {
+        patient: this.config.patientUuid,
+        encounterType: e,
+        v: 'custom:(uuid,encounterDatetime,encounterType:(name,description),obs:(id,uuid,value,concept:(id,uuid,name:(display),datatype:(uuid)),groupMembers:(id,uuid,display,value,concept:(id,uuid,name:(display),datatype:(uuid))))',
+        limit: this.config.maxRecords || 4,
+        fromdate: this.widgetsCommons.maxAgeToDate(this.config.maxAge),
+        order: this.order
+      }).then(response => response.results)
+    );
+
+    this.$q.all(encounterPromises).then((encounterSets) => {
+      for (let encounterSet of encounterSets){
+        this.addToSimpleEncs(encounterSet); 
       }
-
-      this.$q.all(promises).then((dataArray) => {
-        for (var n = 0; n < dataArray.length; n++){
-          this.parseEncounters(dataArray[n]); 
-        }
-      });
-    }
-  }
-
-  getMaxRecords() {
-    if (this.config.maxRecords == '' || angular.isUndefined(this.config.maxRecords)) {
-      return 4;
-    } else {
-      return this.config.maxRecords;
-    }
+    });
   }
 
   isRetired(obs) {
-    let retired = false;
-    if (obs && angular.isDefined(obs.value) && angular.isDefined(obs.value.retired)) {
-      retired = obs.value.retired;
-    }
-    return retired;
+    return Boolean(obs && obs.value && obs.value.retired);
   }
 
-  displayObs(obs) {
-    let display = "";
-    if (obs.value != null) {
-      if (angular.isDefined(obs.value.display)) {
-        //If value is a concept
-        display = obs.value.display;
-      }
-      else if (['8d4a505e-c2cc-11de-8d13-0010c6dffd0f',
-          '8d4a591e-c2cc-11de-8d13-0010c6dffd0f',
-          '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].indexOf(obs.concept.datatype.uuid) > -1) {
-        //If value is date, time or datetime
-        var date = this.$filter('date')(new Date(obs.value), this.config.dateFormat);
-        display = date;
-      } else {
-        display = obs.value;
-      }
+  getObsValue(obs) {
+    if (['8d4a505e-c2cc-11de-8d13-0010c6dffd0f',
+        '8d4a591e-c2cc-11de-8d13-0010c6dffd0f',
+        '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].includes(obs.concept.datatype.uuid)) {
+        // If value is date, time or datetime
+        return this.$filter('date')(new Date(obs.value), this.config.dateFormat);
+    } else if (angular.isDefined(obs.value.display)) {
+        // If value is a concept
+        return this.config.useConceptNameForValue ? obs.value.concept.display : obs.value.display
+    } else {
+        return obs.value;
     }
-    return display;
   }
 
-  getConfigConceptsAsArray(commaDelimitedConcepts) {
-    let conceptArray = commaDelimitedConcepts.replace(" ", "").split(",");
-    if (conceptArray !== null && conceptArray.length > 0) {
-      for (let i = 0; i < conceptArray.length; i++) {
-        let conceptKey = conceptArray[i].trim();
-        // initialize the conceptsMap object
-        if (typeof this.conceptsMap[conceptKey] === 'undefined') {
-          this.conceptsMap[conceptKey] = null;
+  addToSimpleEncs(encounters) {
+    for (let encounter of encounters) {
+      const conceptKeys = Object.keys(this.conceptsMap);
+      // all normal concepts will go in one row
+      const foundObsByUuid = {};
+      for (let obs of encounter.obs) {
+        // see if the concept matches
+        if (conceptKeys.includes(obs.concept.uuid)) {
+          foundObsByUuid[obs.concept.uuid] = obs;
         }
-      }
-    }
-    return conceptArray;
-  }
-
-  getConceptWithShortName(concept) {
-    let lastShortName = null;
-    for(let i=0; i < concept.names.length; i++) {
-      let conceptName = concept.names[i];
-      if (conceptName.conceptNameType == 'SHORT') {
-        lastShortName = conceptName.display;
-        if (this.sessionLocale !== null && this.sessionLocale === conceptName.locale) {
-          // we found a SHORT name that matches the locale of the current session
-          break;
-        }
-      }
-    }
-    if (lastShortName !== null && lastShortName.length > 0) {
-      concept.display = lastShortName;
-    }
-    return concept;
-  }
-
-
-  parseEncounters(encounters) {
-    angular.forEach(encounters, (encounter) => {
-      let searchObs = {};
-      angular.forEach(encounter.obs, (obs) => {
-        let conceptKeys = Object.keys(this.conceptsMap);
-
-        if (conceptKeys.findIndex(conceptKey => conceptKey === obs.concept.uuid) >= 0) {
-          //we found an obs match
-          searchObs[obs.concept.uuid] = obs;
-        }
-        if (obs.groupMembers != null && obs.groupMembers.length > 0) {
-          // need to search the groupMembers
-          let foundObs = this.parseGroupMembers(obs.groupMembers, conceptKeys);
-          if (typeof foundObs !== 'undefined' && foundObs !== null && Object.keys(foundObs).length > 0) {
-            if (Object.keys(foundObs).every(item => conceptKeys.includes(item))) {
-              //this is a complete pair of matching obs with a given concept uuid within the same obsGroup
-              let enc = {
-                encounterType: encounter.encounterType.name,
-                encounterDatetime: encounter.encounterDatetime,
-                obs: foundObs
-              };
-              this.simpleEncs.push(enc);
-            } else {
-              // we have an incomplete match, just add the values to the existing object
-              for (key in Object.keys(foundObs)){
-                searchObs[key] = searchObs[key];
-              }
-            }
+        // add a row for each group with matches
+        if (obs.groupMembers) {
+          const foundMembers = obs.groupMembers.filter(member => conceptKeys.includes(member.concept.uuid));
+          if (foundMembers) {
+            const foundMembersByUuid = Object.fromEntries(foundMembers.map(m => [m.concept.uuid, m]));
+            this.simpleEncs.push({
+              encounterType: encounter.encounterType.name,
+              encounterDatetime: encounter.encounterDatetime,
+              obs: foundMembersByUuid
+            });
           }
         }
-      });
-
-      if (Object.keys(searchObs).length > 0) {
-        let tempEnc = {
+      }
+      if (Object.keys(foundObsByUuid).length > 0) {
+        this.simpleEncs.push({
           encounterType: encounter.encounterType.name,
           encounterDatetime: encounter.encounterDatetime,
-          obs: searchObs
-        };
-        this.simpleEncs.push(tempEnc);
+          obs: foundObsByUuid
+        });
       }
       // if the widget was configured to display the obs concept SHORT name instead of the default obs.value.display value
       // By default, the widget displays the obs.value.display property
-      if (this.config.useConceptShortName && this.config.useConceptShortName === 'true') {
+      if (this.config.useConceptShortName) {
         this.updateWithConceptShortNames(this.simpleEncs);
       }
-    });
+    }
   }
 
   /**
@@ -209,44 +138,20 @@ export default class ObsAcrossEncountersController {
    * @param encounters
    */
   updateWithConceptShortNames(encounters) {
-    if (encounters && encounters.length > 0) {
-      angular.forEach(encounters, encounter => {
-        let encounterObs = encounter.obs;
-        for (const prop in encounterObs) {
-          let obs = encounterObs[prop];
-          let conceptUuid = null;
-          // if the obs value is coded then we try to look for the short names of the coded answers
-          if (angular.isDefined(obs.value.concept) ) {
-            // some obs.value nodes contain the concept property that points to the concept
-            conceptUuid = obs.value.concept.uuid;
-          } else if (angular.isDefined(obs.value.uuid)) {
-            // and other coded obs(e.g. Drug Frequency) do not contain a child concept property
-            conceptUuid = obs.value.uuid;
-          }
-          if (conceptUuid !== null && conceptUuid.length > 0) {
-            this.openmrsRest.get("concept/" + conceptUuid, {
-              v: this.CONCEPT_CUSTOM_REP
-            }).then((concept) => {
-              let shortDisplay = this.getConceptWithShortName(concept);
-              obs.value.display = shortDisplay.display;
-            }, function (err) {
-              console.log(`failed to retrieve concept ${conceptUuid}, ${err}`);
-            });
-          }
+    for (let encounter of encounters) {
+      for (let obs of encounter.obs) {
+        // if the obs value is coded then we try to look for the short names of the coded answers
+        // some obs.value nodes contain the concept property that points to the concept
+        // and other coded obs(e.g. Drug Frequency) do not contain a child concept property
+        const conceptUuid = obs.value.concept ? obs.value.concept.uuid : obs.value.uuid;
+        if (conceptUuid) {
+          this.openmrsRest.get("concept/" + conceptUuid, {
+            v: this.CONCEPT_CUSTOM_REP
+          }).then((concept) => {
+            obs.value.display = this.widgetsCommons.getConceptName(concept, "shortName", this.sessionLocale);
+          }).catch(err => console.error(`failed to retrieve concept ${conceptUuid}, ${err}`));
         }
-      });
+      }
     }
   }
-
-  parseGroupMembers(groupMembers, concepts) {
-    let matchObs = {};
-    angular.forEach(groupMembers, (obs) => {
-      if (concepts.includes(obs.concept.uuid)) {
-        //we found an obs match
-        matchObs[obs.concept.uuid] = obs;
-      }
-    });
-    return matchObs;
-  }
-
 }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -80,14 +80,10 @@ export default class ObsAcrossEncountersController {
   }
 
   getObsValue(obs) {
-    if (['8d4a505e-c2cc-11de-8d13-0010c6dffd0f',
-        '8d4a591e-c2cc-11de-8d13-0010c6dffd0f',
-        '8d4a5af4-c2cc-11de-8d13-0010c6dffd0f'].includes(obs.concept.datatype.uuid)) {
-        // If value is date, time or datetime
+    if (this.widgetsCommons.hasDatatypeDateOrSimilar(obs.concept)) {
         return this.$filter('date')(new Date(obs.value), this.config.dateFormat);
-    } else if (obs.value.concept) {
-        // If value is a concept
-        return this.config.useConceptNameForValue ? obs.value.concept.display : obs.value.display
+    } else if (this.widgetsCommons.isDrug(obs.value)) {
+        return this.config.useConceptNameForDrugValues ? obs.value.concept.display : obs.value.display
     } else {
         return obs.value.display || obs.value;
     }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
@@ -42,11 +42,11 @@
     </thead>
     <tbody>
         <tr ng-repeat="encounter in $ctrl.simpleEncs| orderBy: '-encounterDatetime'">
-            <th ng-if="$ctrl.config.showEncounterTypeName">{{encounter.encounterType | translate }}</th>
-            <th>{{encounter.encounterDatetime | date: $ctrl.config.dateFormat}}</th>
-            <th ng-repeat="(key,value) in $ctrl.conceptsMap" ng-class="($ctrl.isRetired(encounter.obs[key])) ? 'retiredConcept' : ''">
-                {{ encounter.obs[key] ? $ctrl.displayObs(encounter.obs[key]) : '' }}
-            </th>
+            <td ng-if="$ctrl.config.showEncounterTypeName">{{encounter.encounterType | translate }}</td>
+            <td>{{encounter.encounterDatetime | date: $ctrl.config.dateFormat}}</td>
+            <td ng-repeat="(key,value) in $ctrl.conceptsMap" ng-class="($ctrl.isRetired(encounter.obs[key])) ? 'retiredConcept' : ''">
+                {{ encounter.obs[key] ? $ctrl.getObsValue(encounter.obs[key]) : '' }}
+            </td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
PIH ticket https://pihemr.atlassian.net/browse/UHM-4499

This includes very little functional change. I will indicate it in the comments.

Definitely use "hide whitespace changes" when reviewing.

It should be noted that although the [Documentation](https://wiki.openmrs.org/display/docs/Patient+Summary+Widget+Documentation#PatientSummaryWidgetDocumentation-conceptencountersObsAcrossEncounters) claims that `concepts` can be specified by ID, UUID, FSN, or Map, it's clear from the code that only UUID could possibly have worked. I haven't attempted to fix that in this PR.