### PR TITLE
RA-1828: Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/api/src/main/java/org/openmrs/module/coreapps/parser/ParseEncounterToJson.java
+++ b/api/src/main/java/org/openmrs/module/coreapps/parser/ParseEncounterToJson.java
@@ -93,11 +93,7 @@ public class ParseEncounterToJson {
             simpleEncounter.put("canDelete", true);
         }
 
-        if (verifyIfUserHasPermissionToEditAnEncounter(encounter, authenticatedUser, canEdit)) {
-            simpleEncounter.put("canEdit", true);
-        } else {
-            simpleEncounter.put("canEdit", false);
-        }
+        simpleEncounter.put("canEdit", verifyIfUserHasPermissionToEditAnEncounter(encounter, authenticatedUser, canEdit));
 
         if (encounter.getVisit() != null) {
             simpleEncounter.put("visitId", encounter.getVisit().getId());


### PR DESCRIPTION
[RA-1828](https://issues.openmrs.org/browse/RA-1828): Return of boolean expressions should not be wrapped into an "if-then-else" statement

Replaced if-then-else statement with a boolean expression. [Issue description](https://issues.openmrs.org/browse/RA-1828).

Please review and merge if all is ok.