### PR TITLE
RA-1890 - Find Patient should be customizable to include additional p…

### DIFF
--- a/omod/src/main/compass/sass/patientsearch/patientSearchWidget.scss
+++ b/omod/src/main/compass/sass/patientsearch/patientSearchWidget.scss
@@ -97,6 +97,7 @@ $green: #51A351;
   color: $green;
   padding: 1px 2px;
   border-radius: 4px;
+  margin-left: 5px;
 }
 
 img.search-spinner{

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/findpatient/FindPatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/findpatient/FindPatientPageController.java
@@ -33,6 +33,7 @@ public class FindPatientPageController {
         } else {
 	        model.addAttribute("registrationAppLink", app.getConfig().get("registrationAppLink").getTextValue());
         }
+        model.addAttribute("appConfig", app.getConfig());
         BreadcrumbHelper.addBreadcrumbsIfDefinedInApp(app, model, ui);
 	}
 

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/findpatient/FindPatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/findpatient/FindPatientPageController.java
@@ -33,7 +33,7 @@ public class FindPatientPageController {
         } else {
 	        model.addAttribute("registrationAppLink", app.getConfig().get("registrationAppLink").getTextValue());
         }
-        model.addAttribute("appConfig", app.getConfig());
+        model.addAttribute("columnConfig", app.getConfig().get("columnConfig"));
         BreadcrumbHelper.addBreadcrumbsIfDefinedInApp(app, model, ui);
 	}
 

--- a/omod/src/main/webapp/fragments/patientsearch/patientSearchWidget.gsp
+++ b/omod/src/main/webapp/fragments/patientsearch/patientSearchWidget.gsp
@@ -70,7 +70,7 @@
             locale: '${ locale }',
             defaultLocale: '${ defaultLocale }',
             attributeTypes: listableAttributeTypes,
-            identifierTypes: ${identifierTypes},
+            columnConfig: ${columnConfig},
             messages: {
                 info: '${ ui.message("coreapps.search.info") }',
                 first: '${ ui.message("coreapps.search.first") }',

--- a/omod/src/main/webapp/fragments/patientsearch/patientSearchWidget.gsp
+++ b/omod/src/main/webapp/fragments/patientsearch/patientSearchWidget.gsp
@@ -31,6 +31,9 @@
             <% listingAttributeTypeNames.each { attributeName -> %>
                 patientObj["${ ui.encodeHtml(attributeName) }"] = "${ it.getAttribute(attributeName) ? ui.encodeHtml(String.valueOf(it.getAttribute(attributeName))) :'' }";
             <% } %>
+            <% it.identifiers.each { patId -> %>
+                patientObj["${ patId.identifierType.uuid }"] = "${ ui.encodeHtml(patId.identifier) }";
+            <% } %>
             lastViewedPatients.push(patientObj);
         <% }
     } %>
@@ -67,6 +70,7 @@
             locale: '${ locale }',
             defaultLocale: '${ defaultLocale }',
             attributeTypes: listableAttributeTypes,
+            identifierTypes: ${identifierTypes},
             messages: {
                 info: '${ ui.message("coreapps.search.info") }',
                 first: '${ ui.message("coreapps.search.first") }',

--- a/omod/src/main/webapp/pages/findpatient/findPatient.gsp
+++ b/omod/src/main/webapp/pages/findpatient/findPatient.gsp
@@ -25,10 +25,12 @@ ${ ui.includeFragment("coreapps", "patientsearch/patientSearchWidget",
         [ afterSelectedUrl: afterSelectedUrl,
           showLastViewedPatients: showLastViewedPatients,
           breadcrumbOverride: breadcrumbs,
-          registrationAppLink: registrationAppLink])}
+          registrationAppLink: registrationAppLink,
+          appConfig: appConfig])}
 <% } else { %>
 ${ ui.includeFragment("coreapps", "patientsearch/patientSearchWidget",
         [ afterSelectedUrl: afterSelectedUrl,
           showLastViewedPatients: showLastViewedPatients,
-          registrationAppLink: registrationAppLink ])}
+          registrationAppLink: registrationAppLink,
+          appConfig: appConfig])}
 <% } %>

--- a/omod/src/main/webapp/pages/findpatient/findPatient.gsp
+++ b/omod/src/main/webapp/pages/findpatient/findPatient.gsp
@@ -26,11 +26,11 @@ ${ ui.includeFragment("coreapps", "patientsearch/patientSearchWidget",
           showLastViewedPatients: showLastViewedPatients,
           breadcrumbOverride: breadcrumbs,
           registrationAppLink: registrationAppLink,
-          appConfig: appConfig])}
+          columnConfig: columnConfig])}
 <% } else { %>
 ${ ui.includeFragment("coreapps", "patientsearch/patientSearchWidget",
         [ afterSelectedUrl: afterSelectedUrl,
           showLastViewedPatients: showLastViewedPatients,
           registrationAppLink: registrationAppLink,
-          appConfig: appConfig])}
+          columnConfig: columnConfig])}
 <% } %>

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/patientsearch/PatientSearchWidgetFragmentControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/patientsearch/PatientSearchWidgetFragmentControllerTest.java
@@ -1,0 +1,182 @@
+package org.openmrs.module.coreapps.fragment.controller.patientsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.PatientService;
+import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.openmrs.module.appui.UiSessionContext;
+import org.openmrs.ui.framework.UiFrameworkConstants;
+import org.openmrs.ui.framework.fragment.FragmentModel;
+import org.openmrs.util.OpenmrsConstants;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PatientSearchWidgetFragmentControllerTest {
+	
+	private PatientSearchWidgetFragmentController fragmentController;
+	
+	private FragmentModel model;
+
+	private UiSessionContext sessionContext;
+
+	private HttpServletRequest request;
+
+	@Mock
+	private AdministrationService administrationService;
+
+	@Mock
+	private AppFrameworkService appFrameworkService;
+
+	@Mock
+	private PatientService patientService;
+
+	@Mock
+	private MessageSourceService messageSourceService;
+
+	@Before
+	public void setup() throws Exception {
+		fragmentController = new PatientSearchWidgetFragmentController();
+		model = new FragmentModel();
+		sessionContext = mock(UiSessionContext.class);
+		request = mock(HttpServletRequest.class);
+		when(administrationService.getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_DEFAULT_LOCALE, "en")).thenReturn("en");
+		when(administrationService.getGlobalProperty(UiFrameworkConstants.GP_FORMATTER_DATE_FORMAT)).thenReturn("yyyy-MM-dd");
+		PatientIdentifierType type1 = new PatientIdentifierType();
+		type1.setUuid("type-1-uuid");
+		type1.setName("type-1-name");
+		when(patientService.getPatientIdentifierTypeByUuid("type-1-uuid")).thenReturn(type1);
+		when(patientService.getPatientIdentifierTypeByName("type-1-name")).thenReturn(type1);
+		PatientIdentifierType type2 = new PatientIdentifierType();
+		type2.setUuid("type-2-uuid");
+		type2.setName("type-2-name");
+		when(patientService.getPatientIdentifierTypeByUuid("type-2-uuid")).thenReturn(type2);
+		when(patientService.getPatientIdentifierTypeByName("type-2-name")).thenReturn(type2);
+
+		when(messageSourceService.getMessage(anyString())).thenAnswer(new Answer<Object>() {
+			public Object answer(InvocationOnMock invocationOnMock) {
+				String code = invocationOnMock.getArguments()[0].toString();
+				if (code.equals("messagecode.label")) {
+					return "My Message Code Label";
+				}
+				return code;
+			}
+		});
+	}
+
+	@Test
+	public void controller_shouldReturnEmptyJsonArrayIfNoExtraIdentifierTypesConfigured() {
+		ObjectNode appConfig = objectNode();
+		runController(appConfig);
+		assertEquals("[]", model.getAttribute("identifierTypes"));
+	}
+
+	@Test
+	public void controller_shouldReturnExtraIdentifierTypeConfiguredByName() {
+		ObjectNode appConfig = objectNode("identifierTypes", arrayNode(
+				objectNode("name", "type-1-name")
+		));
+		runController(appConfig);
+		assertEquals("[{\"label\":\"type-1-name\",\"uuid\":\"type-1-uuid\"}]", model.getAttribute("identifierTypes"));
+	}
+
+	@Test
+	public void controller_shouldReturnExtraIdentifierTypeConfiguredByUuid() {
+		ObjectNode appConfig = objectNode("identifierTypes", arrayNode(
+				objectNode("uuid", "type-1-uuid")
+		));
+		runController(appConfig);
+		assertEquals("[{\"label\":\"type-1-name\",\"uuid\":\"type-1-uuid\"}]", model.getAttribute("identifierTypes"));
+	}
+
+	@Test
+	public void controller_shouldReturnIdentifierNameIfNoLabelConfigured() {
+		ObjectNode appConfig = objectNode("identifierTypes", arrayNode(
+				objectNode("uuid", "type-1-uuid")
+		));
+		runController(appConfig);
+		assertEquals("[{\"label\":\"type-1-name\",\"uuid\":\"type-1-uuid\"}]", model.getAttribute("identifierTypes"));
+	}
+
+	@Test
+	public void controller_shouldReturnLabelIfConfigured() {
+		ObjectNode appConfig = objectNode("identifierTypes", arrayNode(
+				objectNode("uuid", "type-1-uuid", "label", "Type 1 Label")
+		));
+		runController(appConfig);
+		assertEquals("[{\"label\":\"Type 1 Label\",\"uuid\":\"type-1-uuid\"}]", model.getAttribute("identifierTypes"));
+	}
+
+	@Test
+	public void controller_shouldReturnLabelFromMessageCodeIfConfigured() {
+		ObjectNode appConfig = objectNode("identifierTypes", arrayNode(
+				objectNode("uuid", "type-1-uuid", "label", "messagecode.label")
+		));
+		runController(appConfig);
+		assertEquals("[{\"label\":\"My Message Code Label\",\"uuid\":\"type-1-uuid\"}]", model.getAttribute("identifierTypes"));
+	}
+
+	protected void runController(ObjectNode appConfig, Boolean showLastViewPatients, String searchByParam, String regLink) {
+		fragmentController.controller(
+				model, sessionContext, request,
+				administrationService, appFrameworkService, patientService, messageSourceService,
+				appConfig, showLastViewPatients, searchByParam, regLink
+		);
+	}
+
+	protected void runController(ObjectNode appConfig) {
+		runController(appConfig, false, "", "/");
+	}
+
+	protected ArrayNode arrayNode(ObjectNode ... nodes) {
+		ArrayNode arrayNode = new ObjectMapper().createArrayNode();
+		for (int i = 0; i < nodes.length; i++) {
+			arrayNode.add(nodes[i]);
+		}
+		return arrayNode;
+	}
+
+	protected ObjectNode objectNode(Object ... obj) {
+
+		ObjectNode objectNode = new ObjectMapper().createObjectNode();
+
+		for (int i = 0; i < obj.length; i=i+2) {
+			String key = (String) obj[i];
+			Object value = obj[i+1];
+
+			if (value instanceof Boolean) {
+				objectNode.put(key, (Boolean) value);
+			}
+			else if (value instanceof String) {
+				objectNode.put(key, (String) value);
+			}
+			else if (value instanceof Integer) {
+				objectNode.put(key, (Integer) value);
+			}
+			else if (value instanceof ArrayNode) {
+				objectNode.put(key, (ArrayNode) value);
+			}
+			else if (value instanceof ObjectNode) {
+				objectNode.put(key, (ObjectNode) value);
+			}
+		}
+
+		return objectNode;
+	}
+}


### PR DESCRIPTION
…atient identifiers

This PR enables adding a list of "identifierTypes" to one's app config for the find patient page, and for this to pass configuration down to the patient search fragment and patient search widget to render additional columns of patient identifiers for each returned patient.

Previous behavior (which is the same as current if no identifierTypes are configured):

![image](https://user-images.githubusercontent.com/356297/107789884-27db5a00-6d20-11eb-8592-041a0de4763f.png)

New behavior that allows configuring additional identifier types:

![image](https://user-images.githubusercontent.com/356297/107790047-5822f880-6d20-11eb-99fd-3c1d12642bef.png)

This supports rendering custom labels for each identifier column header.  The above example uses the following configuration added to the app config of the find patient app, which demonstrates that this can be configured with the uuid or name of the identifier type, and with a custom label or message code for the header.

```  
"identifierTypes": [
    { 
      "name": "HIVEMR-V1", 
      "label": "HIVEMR ID"
    },
    {
      "uuid": "3B954DB1-0D41-498E-A3F9-1E20CCC47323", 
      "label": "ui.i18n.PatientIdentifierType.name.3B954DB1-0D41-498E-A3F9-1E20CCC47323"
    }
  ]
```