### PR TITLE
RA-1871: Fix for the missing Health Trend Summary in 2.11 patient dashboard

### DIFF
--- a/omod/src/main/resources/apps/dashboardWidgets_app.json
+++ b/omod/src/main/resources/apps/dashboardWidgets_app.json
@@ -33,12 +33,13 @@
       "icon": "icon-user-md",
       "label": "coreapps.clinicianfacing.healthTrendSummary",
       "concepts": "5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "encounterType": "123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "maxRecords": "5",
       "maxAge": "1m"
     },
     "extensions": [
       {
-        "id": "${project.parent.groupId}.${project.parent.artifactId}.mostRecentVitals.clinicianDashboardFirstColumn",
+        "id": "org.openmrs.module.coreapps.mostRecentVitals.clinicianDashboardFirstColumn",
         "appId": "coreapps.obsAcrossEncounters",
         "extensionPointId": "patientDashboard.firstColumnFragments",
         "extensionParams": {


### PR DESCRIPTION
The JIRA ticket describes an error because of which the "Health Trend Summary" is missing in the patient dashboard of Refapp 2.11.0. The pull request is to merge one commit to fix the ticket RA-1871 described at the below link:
https://issues.openmrs.org/browse/RA-1871