### PR TITLE
RA-1864: Handling undefined encounterType and encounterTypes attribut…

### DIFF
--- a/omod/src/main/resources/apps/dashboardWidgets_app.json
+++ b/omod/src/main/resources/apps/dashboardWidgets_app.json
@@ -33,7 +33,6 @@
       "icon": "icon-user-md",
       "label": "coreapps.clinicianfacing.healthTrendSummary",
       "concepts": "5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-      "encounterType": "123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "maxRecords": "5",
       "maxAge": "1m"
     },

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -55,7 +55,7 @@ export default class ObsAcrossEncountersController {
 
   fetchEncounters() {
     const encounterTypes = this.config.encounterTypes ? this.config.encounterTypes.split(',').map(c => c.trim()) : [];
-    const legacyEncounterTypes = this.config.encounterType ? this.config.encounterType.split(',').map(c => c.trim()) : [];
+    const legacyEncounterTypes = this.config.encounterType ? this.config.encounterType.split(',').map(c => c.trim()) : ["123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"];
     encounterTypes.push(...legacyEncounterTypes);
 
     const encounterPromises = encounterTypes.map(e =>


### PR DESCRIPTION
…es in the obsacrossencounters widget configuration

This Pull Request fixes the JIRA ticket: https://issues.openmrs.org/browse/RA-1864

The attributes  “encounterType” and “encounterTypes” are now optional while configuring the widget “obsacrossencounters” (and they  need not be defined in the widget config file: “/coreapps-omod/src/main/resources/apps/dashboardWidgets_app.json”), the file “/coreapps-omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js” has been altered to handle the logic for ‘null’ values.