### PR TITLE
EMPT-78: Fixed XSS Vulnerability in Visit Type

### DIFF
--- a/omod/src/main/webapp/fragments/patientdashboard/visitIncludes.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/visitIncludes.gsp
@@ -166,7 +166,7 @@
 	                                        jq("#visit-visittype-drop-down").val(${type.id});
 	                                    </script>
 	                                <% } %>
-	                                <option class="dialog-drop-down small" value ="${type.id}">${ ui.format(type) }</option>
+	                                <option class="dialog-drop-down small" value ="${type.id}">${ui.encodeHtmlContent(ui.format(type))}</option>
 	                                <% } %>
 	                            </select>
 	                        </td>


### PR DESCRIPTION
### Description of what I changed
Added the `ui.encodeHtmlContent()` to `ui.format(type)` in `visitIncludes.gsp` in order to prevent XSS.

### Link to ticket
https://issues.openmrs.org/browse/RA-1865

### Issue I worked on
When adding a new visit type, one could submit `<script>alert("xss")</script>` as the type name. Then, upon navigating to the patient page for any patient, this script would be loaded and ran.

### Before fix
Malicious visit type name.
![image](https://user-images.githubusercontent.com/29798975/111505124-ae6bc880-871e-11eb-9cc3-d7f6a0b68b37.png)
Script executed on patient page.
![image](https://user-images.githubusercontent.com/29798975/111505503-128e8c80-871f-11eb-9b4c-cde3ba99933b.png)

### After fix
No script executed, visit type is shown properly escaped.
![image](https://user-images.githubusercontent.com/29798975/111505814-66997100-871f-11eb-9644-398021f74f04.png)

### Steps to reproduce

1. Login to OpenMRS as admin.
2. If you have no patients created, create a patient with any information.
3. Select "Configure Metadata"
4. Select "Add New Visit Type"
5. Create a new visit type with name `<script>alert("xss")</script>` and description `test`
6. From the main page, select "Find Patient Record"
7. Click on the row for any patient
8. When loading the patient page, the `alert("xss")` will be executed.

