### PR TITLE
RA-1833 Remove redudant toString() method calls

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/dashboardwidgets/DashboardWidgetFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/dashboardwidgets/DashboardWidgetFragmentController.java
@@ -51,7 +51,7 @@ public class DashboardWidgetFragmentController {
             appConfig.put("JSDateFormat", adminService.getGlobalProperty(UiFrameworkConstants.GP_FORMATTER_JS_DATE_FORMAT, "YYYY-MMM-DD"));
         }
         appConfig.put("locale", Context.getLocale().toString());
-        appConfig.put("language", Context.getLocale().getLanguage().toString());
+        appConfig.put("language", Context.getLocale().getLanguage());
 
         Map<String, Object> appConfigMap = mapper.convertValue(appConfig, Map.class);
         config.merge(appConfigMap);


### PR DESCRIPTION
### The Issue
[[RA - 1833] - "toString() should never be called on a string object"](https://issues.openmrs.org/browse/RA-1833) 

### Approach
Used the built-in find tool in IntelliJ to find `toString()` method calls, and looked for redundant usages and replaced the found one with just the original string. 