### PR TITLE
RA-1899: Fix broken tests

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -294,7 +294,7 @@
 				<plugin>
 					<groupId>com.github.eirslett</groupId>
 					<artifactId>frontend-maven-plugin</artifactId>
-					<version>1.4</version>
+					<version>1.11.3</version>
 				</plugin>
 			
 				<plugin>

--- a/omod/src/main/resources/apps/dashboardWidgets_app.json
+++ b/omod/src/main/resources/apps/dashboardWidgets_app.json
@@ -33,6 +33,7 @@
       "icon": "icon-user-md",
       "label": "coreapps.clinicianfacing.healthTrendSummary",
       "concepts": "5087AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5088AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "encounterType": "123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
       "maxRecords": "5",
       "maxAge": "1m"
     },

--- a/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.spec.js
+++ b/omod/src/main/web/dashboardwidgets/latestobsforconceptlist/latestobsforconceptlist.spec.js
@@ -72,7 +72,7 @@ const mockObsResults = [
         "groupMembers": null
     },
     {
-        "obsDatetime": new Date().setDate(new Date().getDate() - 1),
+        "obsDatetime": new Date().setHours(new Date().getHours() - 1),
         "concept": {
             "uuid": "uuid-2",
             "display": "History of tobacco use",

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -51,7 +51,7 @@ export default class ObsAcrossEncountersController {
 
   fetchEncounters() {
     const encounterTypes = this.config.encounterTypes ? this.config.encounterTypes.split(',').map(c => c.trim()) : [];
-    const legacyEncounterTypes = this.config.encounterType ? this.config.encounterType.split(',').map(c => c.trim()) : ["123AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"];
+    const legacyEncounterTypes = this.config.encounterType ? this.config.encounterType.split(',').map(c => c.trim()) : [];
     encounterTypes.push(...legacyEncounterTypes);
 
     const encounterQueryParams = {


### PR DESCRIPTION
This addresses three problems identified in [RA-1899](https://issues.openmrs.org/browse/RA-1899):

- When Maven would run the tests, test failures would not cause the build to fail. This was fixed by upgrading the maven plugin.
- The tests are broken. This was fixed by reverting https://github.com/openmrs/openmrs-module-coreapps/pull/387 . More info on the reasoning for that is in [a comment there](https://github.com/openmrs/openmrs-module-coreapps/pull/387#issuecomment-828613239).
- There was a minor error in another test, unrelated to the above. The mock data was fixed.

The reverted commit was attempting to fix https://issues.openmrs.org/browse/RA-1864 and https://issues.openmrs.org/browse/RA-1871 . Those tickets will need re-testing.