### PR TITLE
RA-1875: EMPT32 in systemAdministrationPageControllor.java

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/systemadministration/SystemAdministrationPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/systemadministration/SystemAdministrationPageController.java
@@ -3,6 +3,7 @@ package org.openmrs.module.coreapps.page.controller.systemadministration;
 import java.util.Collections;
 import java.util.List;
 
+import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.service.AppFrameworkService;
 import org.openmrs.module.appui.UiSessionContext;
@@ -17,6 +18,11 @@ public class SystemAdministrationPageController {
                            @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService) {
 
         emrContext.requireAuthentication();
+		
+		if (!emrContext.getCurrentUser().getPrivileges().toString().contains("coreapps.systemAdministration")
+		        && (!emrContext.getCurrentUser().isSuperUser())) {
+			throw new APIAuthenticationException();
+		}
 
         List<Extension> extensions = appFrameworkService.getExtensionsForCurrentUser(SYSTEM_ADMINISTRATION_EXTENSION_POINT);
 

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/systemadministration/SystemAdministrationPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/systemadministration/SystemAdministrationPageController.java
@@ -17,9 +17,8 @@ public class SystemAdministrationPageController {
     public void controller(PageModel model, UiSessionContext emrContext,
                            @SpringBean("appFrameworkService") AppFrameworkService appFrameworkService) {
 
-        emrContext.requireAuthentication();
-		
-		if (!emrContext.getCurrentUser().getPrivileges().toString().contains("coreapps.systemAdministration")
+        emrContext.requireAuthentication();	
+		if (!emrContext.getCurrentUser().hasPrivilege("App: coreapps.systemAdministration")
 		        && (!emrContext.getCurrentUser().isSuperUser())) {
 			throw new APIAuthenticationException();
 		}

--- a/omod/src/main/webapp/fragments/patientheader/activeVisitStatus.gsp
+++ b/omod/src/main/webapp/fragments/patientheader/activeVisitStatus.gsp
@@ -8,7 +8,7 @@
     <% if (config.showVisitTypeOnPatientHeaderSection == false) { %>
         <% if (config.activeVisit.admitted) { %>
         <div class="active-visit-message">
-            ${ui.message("coreapps.patientHeader.activeVisit.inpatient", ui.format(config.activeVisit.latestAdtEncounter.location))}
+            ${ui.message("coreapps.patientHeader.activeVisit.inpatient", ui.encodeHtmlContent(ui.format(config.activeVisit.latestAdtEncounter.location)))}
         </div>
         <% } else { %>
         <div class="active-visit-message">


### PR DESCRIPTION
# Description of what I changed
 I check to see if the user doesn't have the privilege and isn't a superuser. If both of these are true then I throw an APIAuthenticationException

# Issue I worked on
an issue where users without the coreapps.systemAdministration privilege are still able to access the system admin page at /openmrs/coreapps/systemadministration/systemAdministration.page

# It can be reproduced following
-Launch OpenMRS application using the URL: http://localhost:8080/openmrs
--
-Provide following info and click login​Username​ as ​admin​ Password​ ​ as ​admin123 Location as ​Inpatient
-Click on “System Administration”.
-Click on “Manage Accounts”.
-Click on the “Add New Account” button.
-In the “Family Name” field, type in “Megan”.
-In the “Given Name” field, type in “Jones”.
-Select Female as Gender.
-Check the “Add User Account?” checkbox.
-In “Username” field type in “mjones”.
-Select “Full” for “Privilege Level”.
-In “Password” and “Confirm Password” fields type in “Megan123*”.
-Uncheck the “Force Password Change” checkbox.
-Click the “Save” button.
-Go to “System administration"
-Copy the URL.
-Log out of the system.
-In the “Username” field type in “mjones”.
-In the “Password” field type in “Megan123*”.
-Select “Registration Desk” as the Location for this Session.
-Click on the “Login” button to log into the system.
-Go to the URL you copied in 17.

# Link to ticket
https://issues.openmrs.org/browse/RA-1875

@isears