### PR TITLE
RA-1926: Merge Visits: Remove visitId from URL to prevent NPE if that visit was merged

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -43,7 +43,7 @@ public class MergeVisitsPageController {
 
         //Remove the visit ID from URL, in case we merge that visit, it should not be possible to return to it.
         if (!StringUtils.isEmpty(returnUrl) && returnUrl.contains("visitId=") && mergedVisitsIDs.size() > 0) {
-            returnUrl = UpdateURLWithoutMergedVisits(returnUrl, mergedVisitsIDs);
+            returnUrl = updateURLWithoutMergedVisits(returnUrl, mergedVisitsIDs);
         }
 
         model.addAttribute("returnUrl", returnUrl);
@@ -102,7 +102,7 @@ public class MergeVisitsPageController {
      * @param mergedVisitsIDs list of voided visits that have been merged.
      * @return The return URL, without the visit param if that visit was merged.
      */
-    private String UpdateURLWithoutMergedVisits(String returnUrl, List<String> mergedVisitsIDs) {
+    public String updateURLWithoutMergedVisits(String returnUrl, List<String> mergedVisitsIDs) {
         //Pattern to get the visitID from url
         Pattern pat = Pattern.compile("(?<=visitId=)[^&]+");
         Matcher urlVisitId = pat.matcher(returnUrl);

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -43,7 +43,7 @@ public class MergeVisitsPageController {
 
         //Remove the visit ID from URL, in case we merge that visit, it should not be possible to return to it.
         if (!StringUtils.isEmpty(returnUrl) && returnUrl.contains("visitId=") && mergedVisitIds.size() > 0) {
-            returnUrl = updateVisitIdUrlParameter(returnUrl, mergedVisitIds);
+            returnUrl = removeVisitIdFromURLIfVisitWasMerged(returnUrl, mergedVisitIds);
         }
 
         model.addAttribute("returnUrl", returnUrl);
@@ -95,17 +95,17 @@ public class MergeVisitsPageController {
 
 
     /**
-     * If some of the merged visit IDs are on the return url,  it scraps the visitId param altogether off the UR
+     * If some of the merged visit IDs are on the return url, it scraps the visitId param altogether off the URL
      * so it doesn't return to a visit that no longer exists.
      */
-    public String updateVisitIdUrlParameter(String returnUrl, List<String> mergedVisitsIDs) {
+    public String removeVisitIdFromURLIfVisitWasMerged(String returnUrl, List<String> mergedVisitsIDs) {
         //Pattern to get the visitID from url
         Pattern pat = Pattern.compile("(?<=visitId=)[^&]+");
         Matcher urlVisitId = pat.matcher(returnUrl);
         //If find some visitID on url.
         if (urlVisitId.find()) {
-            for (String s : mergedVisitsIDs.get(0).split(",")) {
-                if (urlVisitId.group(0).equals(s)) {
+            for (String mergedVisitId : mergedVisitsIDs.get(0).split(",")) {
+                if (urlVisitId.group(0).equals(mergedVisitId)) {
                     //remove the visitID from url
                     returnUrl = returnUrl.replaceAll("(&visitId[^&]+)", "");
                     break;

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -31,7 +31,7 @@ public class MergeVisitsPageController {
                              PageModel model, @SpringBean AdtService service,
                              @SpringBean("locationService") LocationService locationService,
                              @RequestParam(value = "returnUrl", required = false) String returnUrl,
-                             @RequestParam(value = "mergedVisitsIDs", required = false) List<String> mergedVisitsIDs) {
+                             @RequestParam(value = "mergedVisitIds", required = false) List<String> mergedVisitIds) {
 
 
         if (patient.isVoided() || patient.isPersonVoided()) {
@@ -42,8 +42,8 @@ public class MergeVisitsPageController {
         model.addAttribute("patient", patientDomainWrapper);
 
         //Remove the visit ID from URL, in case we merge that visit, it should not be possible to return to it.
-        if (!StringUtils.isEmpty(returnUrl) && returnUrl.contains("visitId=") && mergedVisitsIDs.size() > 0) {
-            returnUrl = updateURLWithoutMergedVisits(returnUrl, mergedVisitsIDs);
+        if (!StringUtils.isEmpty(returnUrl) && returnUrl.contains("visitId=") && mergedVisitIds.size() > 0) {
+            returnUrl = updateVisitIdUrlParameter(returnUrl, mergedVisitIds);
         }
 
         model.addAttribute("returnUrl", returnUrl);
@@ -68,7 +68,8 @@ public class MergeVisitsPageController {
                        @SpringBean AdtService service,
                        UiUtils ui,
                        HttpServletRequest request, PageModel model) {
-        List<String> mergedVisitsIDs = new ArrayList<String>();
+
+        List<String> mergedVisitIds = new ArrayList<String>();
         if (patient.isVoided() || patient.isPersonVoided()) {
             return "redirect:" + ui.pageLink("coreapps", "patientdashboard/deletedPatient",
                     SimpleObject.create("patientId", patient.getId().toString()));
@@ -84,25 +85,19 @@ public class MergeVisitsPageController {
                 request.getSession().setAttribute(AppUiConstants.SESSION_ATTRIBUTE_TOAST_MESSAGE, "true");
             }
 
-            for (int i = 1; i < mergeVisits.size(); i++) {
-                mergedVisitsIDs.add(mergeVisits.get(i).toString());
+           for (int i = 1; i < mergeVisits.size(); i++) {
+                mergedVisitIds.add(mergeVisits.get(i).toString());
             }
         }
-
-
-        return "redirect:" + ui.pageLink("coreapps", "mergeVisits", SimpleObject.create("patientId", patient.getId(), "returnUrl", returnUrl, "mergedVisitsIDs", mergedVisitsIDs));
+        return "redirect:" + ui.pageLink("coreapps", "mergeVisits", SimpleObject.create("patientId", patient.getId(), "returnUrl", returnUrl, "mergedVisitIds", mergedVisitIds));
     }
 
 
     /**
-     * This method receives the returnUrl and the list of the merged visit IDs
-     * If some of the merged visit IDs are on the return url, it will remove that parameter from the url
+     * If some of the merged visit IDs are on the return url,  it scraps the visitId param altogether off the UR
      * so it doesn't return to a visit that no longer exists.
-     * @param returnUrl the return URL.
-     * @param mergedVisitsIDs list of voided visits that have been merged.
-     * @return The return URL, without the visit param if that visit was merged.
      */
-    public String updateURLWithoutMergedVisits(String returnUrl, List<String> mergedVisitsIDs) {
+    public String updateVisitIdUrlParameter(String returnUrl, List<String> mergedVisitsIDs) {
         //Pattern to get the visitID from url
         Pattern pat = Pattern.compile("(?<=visitId=)[^&]+");
         Matcher urlVisitId = pat.matcher(returnUrl);

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -85,7 +85,7 @@ public class MergeVisitsPageController {
                 request.getSession().setAttribute(AppUiConstants.SESSION_ATTRIBUTE_TOAST_MESSAGE, "true");
             }
 
-           for (int i = 1; i < mergeVisits.size(); i++) {
+            for (int i = 1; i < mergeVisits.size(); i++) {
                 mergedVisitIds.add(mergeVisits.get(i).toString());
             }
         }

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -15,7 +15,7 @@ import org.openmrs.ui.framework.annotation.InjectBeans;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
 import org.openmrs.ui.framework.page.Redirect;
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -85,6 +85,7 @@ public class MergeVisitsPageController {
                 request.getSession().setAttribute(AppUiConstants.SESSION_ATTRIBUTE_TOAST_MESSAGE, "true");
             }
 
+            //Pass by all visits except the first one.
             for (int i = 1; i < mergeVisits.size(); i++) {
                 mergedVisitIds.add(mergeVisits.get(i).toString());
             }

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -15,6 +15,7 @@ import org.openmrs.ui.framework.annotation.InjectBeans;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
 import org.openmrs.ui.framework.page.Redirect;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,6 +35,11 @@ public class MergeVisitsPageController {
 
         patientDomainWrapper.setPatient(patient);
         model.addAttribute("patient", patientDomainWrapper);
+
+        //Remove the visit ID from URL, in case we merge that visit, it should not be possible to return to it.
+        if (!StringUtils.isEmpty(returnUrl) && returnUrl.contains("visitId=")) {
+            returnUrl = returnUrl.replaceAll("(&visitId[^&]+)", "&visitId=");
+        }
 		model.addAttribute("returnUrl", returnUrl);
 
         Location sessionLocation = sessionContext.getSessionLocation();

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageController.java
@@ -98,7 +98,7 @@ public class MergeVisitsPageController {
      * If some of the merged visit IDs are on the return url, it scraps the visitId param altogether off the URL
      * so it doesn't return to a visit that no longer exists.
      */
-    public String removeVisitIdFromURLIfVisitWasMerged(String returnUrl, List<String> mergedVisitsIDs) {
+    protected String removeVisitIdFromURLIfVisitWasMerged(String returnUrl, List<String> mergedVisitsIDs) {
         //Pattern to get the visitID from url
         Pattern pat = Pattern.compile("(?<=visitId=)[^&]+");
         Matcher urlVisitId = pat.matcher(returnUrl);

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/MergeVisitsPageControllerTest.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.coreapps.fragment.controller.visit;
+
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.openmrs.module.coreapps.page.controller.MergeVisitsPageController;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+public class MergeVisitsPageControllerTest {
+   MergeVisitsPageController controller;
+
+
+
+   @Before
+   public void setup() {
+      controller = new MergeVisitsPageController();
+
+   }
+   @Test
+   public void test_shouldRemoveVisitParameterFromReturnURL()  {
+      List<String> MERGED_VISITS_IDS = Arrays.asList("6,7,8,9");
+      String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
+      String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
+      Assert.assertEquals(controller.updateURLWithoutMergedVisits( RETURN_URL, MERGED_VISITS_IDS ) , EXPECTED_URL);
+   }
+
+   @Test
+   public void test_shouldNotRemoveVisitParameterFromReturnURL() {
+      List<String> MERGED_VISITS_IDS = Arrays.asList("3,4,5,6");
+      String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
+      Assert.assertEquals(controller.updateURLWithoutMergedVisits( RETURN_URL, MERGED_VISITS_IDS ) , RETURN_URL);
+   }
+
+}

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -23,9 +23,10 @@ import java.util.List;
 
 
 public class MergeVisitsPageControllerTest {
+
     MergeVisitsPageController controller;
-    private final String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-    private final String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
+    private final String RETURN_URL_WITH_VISIT_ID = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
+    private final String RETURN_URL_WITHOUT_VISIT_ID = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
     @Before
     public void setup() {
         controller = new MergeVisitsPageController();
@@ -35,13 +36,13 @@ public class MergeVisitsPageControllerTest {
     @Test
     public void test_shouldRemoveVisitParameterFromReturnURL() {
         List<String> merged_visits_ids = Arrays.asList("6,7,8,9");
-        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), EXPECTED_URL);
+        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL_WITH_VISIT_ID, merged_visits_ids), RETURN_URL_WITHOUT_VISIT_ID);
     }
 
     @Test
     public void test_shouldNotRemoveVisitParameterFromReturnURL() {
         List<String> merged_visits_ids = Arrays.asList("3,4,5,6");
-        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), RETURN_URL);
+        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL_WITH_VISIT_ID, merged_visits_ids), RETURN_URL_WITH_VISIT_ID);
     }
 
 }

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -3,12 +3,12 @@
  * Version 1.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
  * http://license.openmrs.org
- *
+ * <p>
  * Software distributed under the License is distributed on an "AS IS"
  * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
  * License for the specific language governing rights and limitations
  * under the License.
- *
+ * <p>
  * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
  */
 package org.openmrs.module.coreapps.page.controller;
@@ -23,28 +23,28 @@ import java.util.List;
 
 
 public class MergeVisitsPageControllerTest {
-   MergeVisitsPageController controller;
+    MergeVisitsPageController controller;
 
 
+    @Before
+    public void setup() {
+        controller = new MergeVisitsPageController();
 
-   @Before
-   public void setup() {
-      controller = new MergeVisitsPageController();
+    }
 
-   }
-   @Test
-   public void test_shouldRemoveVisitParameterFromReturnURL()  {
-      List<String> MERGED_VISITS_IDS = Arrays.asList("6,7,8,9");
-      String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-      String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
-      Assert.assertEquals(controller.updateVisitIdUrlParameter( RETURN_URL, MERGED_VISITS_IDS ) , EXPECTED_URL);
-   }
+    @Test
+    public void test_shouldRemoveVisitParameterFromReturnURL() {
+        List<String> MERGED_VISITS_IDS = Arrays.asList("6,7,8,9");
+        String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
+        String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
+        Assert.assertEquals(controller.updateVisitIdUrlParameter(RETURN_URL, MERGED_VISITS_IDS), EXPECTED_URL);
+    }
 
-   @Test
-   public void test_shouldNotRemoveVisitParameterFromReturnURL() {
-      List<String> MERGED_VISITS_IDS = Arrays.asList("3,4,5,6");
-      String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-      Assert.assertEquals(controller.updateVisitIdUrlParameter( RETURN_URL, MERGED_VISITS_IDS ) , RETURN_URL);
-   }
+    @Test
+    public void test_shouldNotRemoveVisitParameterFromReturnURL() {
+        List<String> MERGED_VISITS_IDS = Arrays.asList("3,4,5,6");
+        String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
+        Assert.assertEquals(controller.updateVisitIdUrlParameter(RETURN_URL, MERGED_VISITS_IDS), RETURN_URL);
+    }
 
 }

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -11,7 +11,7 @@
  *
  * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
  */
-package org.openmrs.module.coreapps.fragment.controller.visit;
+package org.openmrs.module.coreapps.page.controller;
 
 
 import org.junit.Assert;

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -25,8 +25,10 @@ import java.util.List;
 public class MergeVisitsPageControllerTest {
 
     MergeVisitsPageController controller;
+
     private final String RETURN_URL_WITH_VISIT_ID = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
     private final String RETURN_URL_WITHOUT_VISIT_ID = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
+
     @Before
     public void setup() {
         controller = new MergeVisitsPageController();

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -18,8 +18,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.openmrs.module.coreapps.page.controller.MergeVisitsPageController;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,14 +37,14 @@ public class MergeVisitsPageControllerTest {
       List<String> MERGED_VISITS_IDS = Arrays.asList("6,7,8,9");
       String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
       String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
-      Assert.assertEquals(controller.updateURLWithoutMergedVisits( RETURN_URL, MERGED_VISITS_IDS ) , EXPECTED_URL);
+      Assert.assertEquals(controller.updateVisitIdUrlParameter( RETURN_URL, MERGED_VISITS_IDS ) , EXPECTED_URL);
    }
 
    @Test
    public void test_shouldNotRemoveVisitParameterFromReturnURL() {
       List<String> MERGED_VISITS_IDS = Arrays.asList("3,4,5,6");
       String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-      Assert.assertEquals(controller.updateURLWithoutMergedVisits( RETURN_URL, MERGED_VISITS_IDS ) , RETURN_URL);
+      Assert.assertEquals(controller.updateVisitIdUrlParameter( RETURN_URL, MERGED_VISITS_IDS ) , RETURN_URL);
    }
 
 }

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -34,17 +34,18 @@ public class MergeVisitsPageControllerTest {
 
     @Test
     public void test_shouldRemoveVisitParameterFromReturnURL() {
-        List<String> MERGED_VISITS_IDS = Arrays.asList("6,7,8,9");
+        List<String> merged_visits_ids = Arrays.asList("6,7,8,9");
         String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
         String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
-        Assert.assertEquals(controller.updateVisitIdUrlParameter(RETURN_URL, MERGED_VISITS_IDS), EXPECTED_URL);
+        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), EXPECTED_URL);
     }
 
     @Test
     public void test_shouldNotRemoveVisitParameterFromReturnURL() {
-        List<String> MERGED_VISITS_IDS = Arrays.asList("3,4,5,6");
+        List<String> merged_visits_ids = Arrays.asList("3,4,5,6");
         String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-        Assert.assertEquals(controller.updateVisitIdUrlParameter(RETURN_URL, MERGED_VISITS_IDS), RETURN_URL);
+        String EXPECTED_URL = RETURN_URL;
+        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), EXPECTED_URL);
     }
 
 }

--- a/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/page/controller/MergeVisitsPageControllerTest.java
@@ -24,8 +24,8 @@ import java.util.List;
 
 public class MergeVisitsPageControllerTest {
     MergeVisitsPageController controller;
-
-
+    private final String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
+    private final String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
     @Before
     public void setup() {
         controller = new MergeVisitsPageController();
@@ -35,17 +35,13 @@ public class MergeVisitsPageControllerTest {
     @Test
     public void test_shouldRemoveVisitParameterFromReturnURL() {
         List<String> merged_visits_ids = Arrays.asList("6,7,8,9");
-        String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-        String EXPECTED_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad";
         Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), EXPECTED_URL);
     }
 
     @Test
     public void test_shouldNotRemoveVisitParameterFromReturnURL() {
         List<String> merged_visits_ids = Arrays.asList("3,4,5,6");
-        String RETURN_URL = "http://localhost:8080/openmrs/coreapps/patientdashboard/patientDashboard.page?patientId=9e121f61-457f-4eaa-9121-62fbb9acdaad&visitId=7";
-        String EXPECTED_URL = RETURN_URL;
-        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), EXPECTED_URL);
+        Assert.assertEquals(controller.removeVisitIdFromURLIfVisitWasMerged(RETURN_URL, merged_visits_ids), RETURN_URL);
     }
 
 }


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/RA-1926
#### What I have done:
Merge Visits: Remove visitId from URL to prevent NPE if that visit was merged