### PR TITLE
RA-1916: Coalesce multiple answers recorded for the same question on ObsAcrossEncounters widget.

### DIFF
--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -103,12 +103,18 @@ export default class ObsAcrossEncountersController {
       });
       for (let uuid of Object.keys(this.conceptsMap)) {
         let obsArray = [];
-        for (let obs of encounter.obs[uuid]) {
-          obsArray.push({
-            value: (obs ? this.getObsValue(obs) : '') || '',
-            className: this.isRetired(obs) ? 'retiredConcept' : ''
-          });
-        }
+         if (angular.isArray(encounter.obs[uuid])) {
+          for (let obs of encounter.obs[uuid]) {
+             obsArray.push({
+               value: (obs ? this.getObsValue(obs) : '') || '',
+               className: this.isRetired(obs) ? 'retiredConcept' : ''
+              });
+            }
+        } else {
+           obsArray.push({
+             value: ''
+           });
+         }
         row.push(obsArray);
       }
     }
@@ -142,7 +148,10 @@ export default class ObsAcrossEncountersController {
           if (foundMembers.length) {
             const foundMembersByUuid = {};
             for (let m of foundMembers) {
-              foundMembersByUuid[m.concept.uuid] = m;
+              if (!foundMembersByUuid[m.concept.uuid]) {
+                foundMembersByUuid[m.concept.uuid] = [];
+              }
+              foundMembersByUuid[m.concept.uuid].push(m);
             }
             this.simpleEncs.push({
               encounterType: encounter.encounterType.name,
@@ -181,11 +190,13 @@ export default class ObsAcrossEncountersController {
   updateWithConceptShortNames(encounters) {
     const resultPromises = [];
     for (let encounter of encounters) {
-      for (let obs of Object.values(encounter.obs)) {
-        if (this.widgetsCommons.isDrug(obs.value)) {
-          resultPromises.push(this.updateWithShortName(obs.value.concept));
-        } else if (this.widgetsCommons.hasDatatypeCoded(obs.concept)) {
-          resultPromises.push(this.updateWithShortName(obs.value));
+      for (let obsArray of Object.values(encounter.obs)) {
+        for (let obs of obsArray) {
+          if (this.widgetsCommons.isDrug(obs.value)) {
+            resultPromises.push(this.updateWithShortName(obs.value.concept));
+          } else if (this.widgetsCommons.hasDatatypeCoded(obs.concept)) {
+            resultPromises.push(this.updateWithShortName(obs.value));
+          }
         }
       }
     }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -103,7 +103,7 @@ export default class ObsAcrossEncountersController {
       });
       for (let uuid of Object.keys(this.conceptsMap)) {
         let obsArray = [];
-         if (angular.isArray(encounter.obs[uuid])) {
+         if (encounter.obs[uuid]) {
           for (let obs of encounter.obs[uuid]) {
              obsArray.push({
                value: (obs ? this.getObsValue(obs) : '') || '',
@@ -111,10 +111,10 @@ export default class ObsAcrossEncountersController {
               });
             }
         } else {
-           obsArray.push({
-             value: ''
-           });
-         }
+          obsArray.push({
+            value: ''
+          });
+        }
         row.push(obsArray);
       }
     }

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -12,6 +12,7 @@ export default class ObsAcrossEncountersController {
     this.simpleEncs = [];
     this.headers = [];
     this.openmrsRest.setBaseAppPath("/coreapps");
+    this.isArray = angular.isArray;
 
     this.output = {
       headers: [],
@@ -100,11 +101,15 @@ export default class ObsAcrossEncountersController {
           this.config.JSDateFormat,
           this.config.language)
       });
-      for (var uuid of Object.keys(this.conceptsMap)) {
-        row.push({
-          value: (encounter.obs[uuid] ? this.getObsValue(encounter.obs[uuid]) : '') || '',
-          className: this.isRetired(encounter.obs[uuid]) ? 'retiredConcept' : ''
-        });
+      for (let uuid of Object.keys(this.conceptsMap)) {
+        let obsArray = [];
+        for (let obs of encounter.obs[uuid]) {
+          obsArray.push({
+            value: (obs ? this.getObsValue(obs) : '') || '',
+            className: this.isRetired(obs) ? 'retiredConcept' : ''
+          });
+        }
+        row.push(obsArray);
       }
     }
   }
@@ -147,7 +152,10 @@ export default class ObsAcrossEncountersController {
           }
         } else // otherwise, add the obs value (if it matches one of our concepts)
           if (conceptKeys.includes(obs.concept.uuid)) {
-          foundObsByUuid[obs.concept.uuid] = obs;
+            if (!foundObsByUuid[obs.concept.uuid]) {
+              foundObsByUuid[obs.concept.uuid] = [];
+            }
+            foundObsByUuid[obs.concept.uuid].push(obs);
         }
       }
       if (Object.keys(foundObsByUuid).length > 0) {

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -103,13 +103,13 @@ export default class ObsAcrossEncountersController {
       });
       for (let uuid of Object.keys(this.conceptsMap)) {
         let obsArray = [];
-         if (encounter.obs[uuid]) {
+        if (encounter.obs[uuid]) {
           for (let obs of encounter.obs[uuid]) {
-             obsArray.push({
-               value: (obs ? this.getObsValue(obs) : '') || '',
-               className: this.isRetired(obs) ? 'retiredConcept' : ''
-              });
-            }
+            obsArray.push({
+              value: (obs ? this.getObsValue(obs) : '') || '',
+              className: this.isRetired(obs) ? 'retiredConcept' : ''
+            });
+          }
         } else {
           obsArray.push({
             value: ''

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
@@ -42,7 +42,7 @@
                     {{ cell.translate ? (cell.value | translate) : cell.value }}
                 </span>
                 <span ng-if="$ctrl.isArray(cell)" ng-repeat="cellElem in cell">
-                    <span ng-class="cellElem.className">{{ cellElem.translate ? (cellElem.value | translate) : cellElem.value }}</span><span>{{ $last ? '' : ',&nbsp;' }}</span>
+                    <span ng-class="cellElem.className">{{ cellElem.translate ? (cellElem.value | translate) : cellElem.value }}{{ $last ? '' : ',&nbsp;' }}</span>
                 </span>
             </td>
         </tr>

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.html
@@ -38,7 +38,12 @@
     <tbody>
         <tr ng-repeat="row in $ctrl.output.rows">
             <td ng-repeat="cell in row" ng-class="cell.className">
-                {{ cell.translate ? (cell.value | translate) : cell.value }}
+                <span ng-if="!$ctrl.isArray(cell)">
+                    {{ cell.translate ? (cell.value | translate) : cell.value }}
+                </span>
+                <span ng-if="$ctrl.isArray(cell)" ng-repeat="cellElem in cell">
+                    <span ng-class="cellElem.className">{{ cellElem.translate ? (cellElem.value | translate) : cellElem.value }}</span><span>{{ $last ? '' : ',&nbsp;' }}</span>
+                </span>
             </td>
         </tr>
     </tbody>

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
@@ -491,14 +491,14 @@ describe('ObsAcrossEncounters', () => {
             expect(ctrl.output.headers).toEqual(['coreapps.date', 'Height (cm)', 'Foot examination results']);
             expect(ctrl.output.rows.length).toEqual(3);
             expect(ctrl.output.rows[0][0]).toEqual({ value: "2021-02-01T07:00:00-05:00"});
-            expect(ctrl.output.rows[0][1].value).toEqual(165);
-            expect(ctrl.output.rows[0][2].value).toEqual("");
+            expect(ctrl.output.rows[0][1][0].value).toEqual(165);
+            expect(ctrl.output.rows[0][2][0].value).toEqual("");
             expect(ctrl.output.rows[1][0]).toEqual({ value: "2021-03-04T07:02:00-05:00"});
-            expect(ctrl.output.rows[1][1].value).toEqual(170);
-            expect(ctrl.output.rows[1][2].value).toEqual("Normal");
+            expect(ctrl.output.rows[1][1][0].value).toEqual(170);
+            expect(ctrl.output.rows[1][2][0].value).toEqual("Normal");
             expect(ctrl.output.rows[2][0]).toEqual({ value: "2021-03-15T08:03:00-04:00"});
-            expect(ctrl.output.rows[2][1].value).toEqual(175);
-            expect(ctrl.output.rows[2][2].value).toEqual("");
+            expect(ctrl.output.rows[2][1][0].value).toEqual(175);
+            expect(ctrl.output.rows[2][2][0].value).toEqual("");
         });
     });
 
@@ -512,11 +512,11 @@ describe('ObsAcrossEncounters', () => {
             expect(ctrl.output.headers).toEqual(['coreapps.date', 'Foot examination results', 'Height (cm)']);
             expect(ctrl.output.rows.length).toEqual(2);
             expect(ctrl.output.rows[0][0]).toEqual({ value: "2021-03-04T07:02:00-05:00"});
-            expect(ctrl.output.rows[0][1].value).toEqual("Normal");
-            expect(ctrl.output.rows[0][2].value).toEqual(170);
+            expect(ctrl.output.rows[0][1][0].value).toEqual("Normal");
+            expect(ctrl.output.rows[0][2][0].value).toEqual(170);
             expect(ctrl.output.rows[1][0]).toEqual({ value: "2021-03-15T08:03:00-04:00"});
-            expect(ctrl.output.rows[1][1].value).toEqual("");
-            expect(ctrl.output.rows[1][2].value).toEqual(175);
+            expect(ctrl.output.rows[1][1][0].value).toEqual("");
+            expect(ctrl.output.rows[1][2][0].value).toEqual(175);
         });
     });
 
@@ -531,16 +531,16 @@ describe('ObsAcrossEncounters', () => {
             expect(ctrl.output.rows.length).toEqual(3);
             expect(ctrl.output.rows[0][0]).toEqual({ value: 'Registration', translate: true });
             expect(ctrl.output.rows[0][1]).toEqual({ value: "2021-02-01T07:00:00-05:00"});
-            expect(ctrl.output.rows[0][2].value).toEqual(165);
-            expect(ctrl.output.rows[0][3].value).toEqual("");
+            expect(ctrl.output.rows[0][2][0].value).toEqual(165);
+            expect(ctrl.output.rows[0][3][0].value).toEqual("");
             expect(ctrl.output.rows[1][0]).toEqual({ value: 'Consult', translate: true });
             expect(ctrl.output.rows[1][1]).toEqual({ value: "2021-03-04T07:02:00-05:00"});
-            expect(ctrl.output.rows[1][2].value).toEqual(170);
-            expect(ctrl.output.rows[1][3].value).toEqual("Normal");
+            expect(ctrl.output.rows[1][2][0].value).toEqual(170);
+            expect(ctrl.output.rows[1][3][0].value).toEqual("Normal");
             expect(ctrl.output.rows[2][0]).toEqual({ value: 'Consult', translate: true });
             expect(ctrl.output.rows[2][1]).toEqual({ value: "2021-03-15T08:03:00-04:00"});
-            expect(ctrl.output.rows[2][2].value).toEqual(175);
-            expect(ctrl.output.rows[2][3].value).toEqual("");
+            expect(ctrl.output.rows[2][2][0].value).toEqual(175);
+            expect(ctrl.output.rows[2][3][0].value).toEqual("");
         });
     });
 
@@ -553,7 +553,7 @@ describe('ObsAcrossEncounters', () => {
         return ctrl.$onInit().then(() => {
             expect(ctrl.output.headers).toEqual(['coreapps.date', 'Height (cm)', 'Foot examination results']);
             expect(ctrl.output.rows.length).toEqual(3);
-            expect(ctrl.output.rows[1][2].value).toEqual("nrml");
+            expect(ctrl.output.rows[1][2][0].value).toEqual("nrml");
         });
     });
 
@@ -566,7 +566,7 @@ describe('ObsAcrossEncounters', () => {
         return ctrl.$onInit().then(() => {
             expect(ctrl.output.headers).toEqual(['coreapps.date', 'Medication orders']);
             expect(ctrl.output.rows.length).toEqual(1);
-            expect(ctrl.output.rows[0][1].value).toEqual("Paracetamol");
+            expect(ctrl.output.rows[0][1][0].value).toEqual("Paracetamol");
         });
     });
 
@@ -580,11 +580,11 @@ describe('ObsAcrossEncounters', () => {
             expect(ctrl.output.headers).toEqual(['coreapps.date', 'Medication orders', 'Prescription instructions, non-coded']);
             expect(ctrl.output.rows.length).toEqual(2);
             expect(ctrl.output.rows[0][0]).toEqual({ value: "2021-03-04T07:02:00-05:00"});
-            expect(ctrl.output.rows[0][1].value).toEqual("Paracetamol 500mg - 10 tabletas");
-            expect(ctrl.output.rows[0][2].value).toEqual("Take with food");
+            expect(ctrl.output.rows[0][1][0].value).toEqual("Paracetamol 500mg - 10 tabletas");
+            expect(ctrl.output.rows[0][2][0].value).toEqual("Take with food");
             expect(ctrl.output.rows[1][0]).toEqual({ value: "2021-03-04T07:02:00-05:00"});
-            expect(ctrl.output.rows[1][1].value).toEqual("");
-            expect(ctrl.output.rows[1][2].value).toEqual("As needed");
+            expect(ctrl.output.rows[1][1][0].value).toEqual("");
+            expect(ctrl.output.rows[1][2][0].value).toEqual("As needed");
         });
     });
 

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
@@ -653,8 +653,8 @@ describe('ObsAcrossEncounters', () => {
             expect(ctrl.output.headers).toEqual(['coreapps.date', 'Affected limb, non-coded']);
             expect(ctrl.output.rows.length).toEqual(1);
             expect(ctrl.output.rows[0][0]).toEqual({ value: "2021-06-01T05:00:00-04:00"});
-            expect(ctrl.output.rows[0][1][0].value).toEqual("Take with food");
-            expect(ctrl.output.rows[0][1][1].value).toEqual("Don't mix with alcohol");
+            expect(ctrl.output.rows[0][1][0].value).toEqual("Left arm");
+            expect(ctrl.output.rows[0][1][1].value).toEqual("Left leg");
         });
     });
 });

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
@@ -17,6 +17,9 @@ import timezoneMock from 'timezone-mock';
 //     - uuid-text
 // Consult
 //   - uuid-numeric
+// Report
+//   - uuid-limb-text
+//   - uuid-limb-text
 const mockEncounters = [
     {
         "uuid": "1a742d56-6528-4eac-b3a5-b222f2120ffa",

--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.spec.js
@@ -264,6 +264,48 @@ const mockEncounters = [
                 "groupMembers": null
             }
         ]
+    },
+    {
+        "uuid": "a8b338cc-3978-43eb-99b5-f1c601ac7e76",
+        "encounterDatetime": "2021-06-01T09:00:00.000-0000",
+        "encounterType": {
+            "name": "Report",
+            "description": "Patient operation report"
+        },
+        "obs": [
+            {
+                "id": 60,
+                "uuid": "c098deb2-187c-4bfe-813a-cb2e1a4138db",
+                "display": "Affected limb, non-coded: Left arm",
+                "concept": {
+                    "id": 231,
+                    "uuid": "uuid-limb-text",
+                    "name": {
+                        "display": "Prescription instructions, non-coded"
+                    },
+                    "datatype": {
+                        "uuid": "8d4a4ab4-c2cc-11de-8d13-0010c6dffd0f"
+                    }
+                },
+                "value": "Left arm"
+            },
+            {
+                "id": 61,
+                "uuid": "c7ee73d9-9aaa-498f-a707-4b5ea8aaa076",
+                "display": "Affected limb, non-coded: Left leg",
+                "concept": {
+                    "id": 231,
+                    "uuid": "uuid-limb-text",
+                    "name": {
+                        "display": "Affected limb, non-coded"
+                    },
+                    "datatype": {
+                        "uuid": "8d4a4ab4-c2cc-11de-8d13-0010c6dffd0f"
+                    }
+                },
+                "value": "Left leg"
+            }
+        ]
     }
 ];
 
@@ -344,6 +386,19 @@ const mockConcepts = {
                 "conceptNameType": "FULLY_SPECIFIED",
                 "localePreferred": true,
                 "name": "Prescription instructions, non-coded"
+            }
+        ]
+    },
+    'uuid-limb-text': {
+        "uuid": "uuid-limb-text",
+        "display": "Affected limb, non-coded",
+        "names": [
+            {
+                "voided": false,
+                "locale": "en",
+                "conceptNameType": "FULLY_SPECIFIED",
+                "localePreferred": true,
+                "name": "Affected limb, non-coded"
             }
         ]
     },
@@ -588,4 +643,18 @@ describe('ObsAcrossEncounters', () => {
         });
     });
 
+    it('should show two obs values on same cell when they\'re answer to same concept within same form', () => {
+        let bindings = { config: { concepts: 'uuid-limb-text', patientUuid: 'some-patient-uuid', encounterTypes: 'Report' }};
+        let ctrl = $componentController('obsacrossencounters', {$scope}, bindings);
+
+        spyOn(ctrl.openmrsRest, "get").and.callFake(fakeGetFunction(mockEncounters));
+
+        return ctrl.$onInit().then(() => {
+            expect(ctrl.output.headers).toEqual(['coreapps.date', 'Affected limb, non-coded']);
+            expect(ctrl.output.rows.length).toEqual(1);
+            expect(ctrl.output.rows[0][0]).toEqual({ value: "2021-06-01T05:00:00-04:00"});
+            expect(ctrl.output.rows[0][1][0].value).toEqual("Take with food");
+            expect(ctrl.output.rows[0][1][1].value).toEqual("Don't mix with alcohol");
+        });
+    });
 });


### PR DESCRIPTION
**Ticket:** [RA-1916](https://issues.openmrs.org/browse/RA-1916)

**Description:**
- Answer obs are treated now as an array so that multiple answers can be presented for a concept within a widget cell
- On the html, when rendering the widget row, if an array is stored for the cell, all elements will be shown separated by a comma
- All elements on the obs array have their own associated css class, allowing to maintain the previous behavior of showing as grayed the voided concepts
- Questions with only one answer are shown as before, maintaining previous behaviour

![image-2021-06-09-10-53-17-925](https://user-images.githubusercontent.com/1031876/123846294-08595e00-d8ca-11eb-950a-34b0d7c3581e.png)

cc @mks-d @dkayiwa 
