### PR TITLE
RA-1945: ParserEncounterIntoSimpleObjects to cast concepts to ConceptNumeric where applicable.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -136,11 +136,11 @@ public class ParserEncounterIntoSimpleObjects {
             SimpleObject simpleObject = SimpleObject.create("obsId", obs.getObsId());
 
             if (obs.getConcept().isNumeric()) {
-                Boolean integerNumber = false;
+                Boolean isIntegerValue = false;
                 if (!conceptService.getConceptNumeric(obs.getConcept().getConceptId()).isAllowDecimal()) {
-                    integerNumber = true;
+                    isIntegerValue = true;
                 }
-                simpleObject.put("integerNumber", integerNumber);
+                simpleObject.put("isIntegerValue", isIntegerValue);
             }
 
             simpleObject.put("question", capitalizeString(uiUtils.format(obs.getConcept())));

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -17,6 +17,7 @@ import org.openmrs.Encounter;
 import org.openmrs.Location;
 import org.openmrs.Obs;
 import org.openmrs.Order;
+import org.openmrs.api.ConceptService;
 import org.openmrs.api.LocationService;
 import org.openmrs.module.emrapi.EmrApiProperties;
 import org.openmrs.module.emrapi.diagnosis.Diagnosis;
@@ -44,14 +45,17 @@ public class ParserEncounterIntoSimpleObjects {
 
     private LocationService locationService;
 
+    private ConceptService conceptService;
+
     private DispositionService dispositionService;
 
     public ParserEncounterIntoSimpleObjects(Encounter encounter, UiUtils uiUtils, EmrApiProperties emrApiProperties,
-                                            LocationService locationService, DispositionService dispositionService) {
+                                            LocationService locationService, ConceptService conceptService, DispositionService dispositionService) {
         this.encounter = encounter;
         this.uiUtils = uiUtils;
         this.emrApiProperties = emrApiProperties;
         this.locationService = locationService;
+        this.conceptService = conceptService;
         this.dispositionService = dispositionService;
     }
 	
@@ -130,6 +134,14 @@ public class ParserEncounterIntoSimpleObjects {
         }
         else {
             SimpleObject simpleObject = SimpleObject.create("obsId", obs.getObsId());
+
+            if (obs.getConcept().isNumeric()) {
+                Boolean integerNumber = false;
+                if (!conceptService.getConceptNumeric(obs.getConcept().getConceptId()).isAllowDecimal()) {
+                    integerNumber = true;
+                }
+                simpleObject.put("integerNumber", integerNumber);
+            }
 
             simpleObject.put("question", capitalizeString(uiUtils.format(obs.getConcept())));
             simpleObject.put("answer", uiUtils.format(obs));

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -19,7 +19,6 @@ import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Concept;
 import org.openmrs.ConceptNumeric;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.module.emrapi.EmrApiProperties;
@@ -44,8 +43,6 @@ public class ParserEncounterIntoSimpleObjects {
 	
 	private UiUtils uiUtils;
 
-    private ConceptService conceptService;
-
 	private EmrApiProperties emrApiProperties;
 
     private LocationService locationService;
@@ -53,13 +50,12 @@ public class ParserEncounterIntoSimpleObjects {
     private DispositionService dispositionService;
 
     public ParserEncounterIntoSimpleObjects(Encounter encounter, UiUtils uiUtils, EmrApiProperties emrApiProperties,
-                                            LocationService locationService, ConceptService conceptService, DispositionService dispositionService) {
+                                            LocationService locationService, DispositionService dispositionService) {
         this.encounter = encounter;
         this.uiUtils = uiUtils;
         this.emrApiProperties = emrApiProperties;
         this.locationService = locationService;
         this.dispositionService = dispositionService;
-        this.conceptService = conceptService;
     }
 	
 	public List<SimpleObject> parseOrders() {

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -40,12 +40,12 @@ public class ParserEncounterIntoSimpleObjects {
 	private Encounter encounter;
 	
 	private UiUtils uiUtils;
-	
+
+    private ConceptService conceptService;
+
 	private EmrApiProperties emrApiProperties;
 
     private LocationService locationService;
-
-    private ConceptService conceptService;
 
     private DispositionService dispositionService;
 
@@ -55,8 +55,8 @@ public class ParserEncounterIntoSimpleObjects {
         this.uiUtils = uiUtils;
         this.emrApiProperties = emrApiProperties;
         this.locationService = locationService;
-        this.conceptService = conceptService;
         this.dispositionService = dispositionService;
+        this.conceptService = conceptService;
     }
 	
 	public List<SimpleObject> parseOrders() {
@@ -129,19 +129,14 @@ public class ParserEncounterIntoSimpleObjects {
 	}
 	
 	private SimpleObject parseObs(Obs obs, Locale locale) {
+        if(obs.getConcept() != null && obs.getConcept().isNumeric()){
+            obs.setConcept(this.conceptService.getConceptNumeric(obs.getConcept().getConceptId()));
+        }
         if ("org.openmrs.Location".equals(obs.getComment())) {
             return (parseObsWithLocationAnswer(obs, locationService.getLocation(Integer.valueOf(obs.getValueText()))));
         }
         else {
             SimpleObject simpleObject = SimpleObject.create("obsId", obs.getObsId());
-
-            if (obs.getConcept().isNumeric()) {
-                Boolean isIntegerValue = false;
-                if (!conceptService.getConceptNumeric(obs.getConcept().getConceptId()).isAllowDecimal()) {
-                    isIntegerValue = true;
-                }
-                simpleObject.put("isIntegerValue", isIntegerValue);
-            }
 
             simpleObject.put("question", capitalizeString(uiUtils.format(obs.getConcept())));
             simpleObject.put("answer", uiUtils.format(obs));

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -128,13 +128,11 @@ public class ParserEncounterIntoSimpleObjects {
 	}
 	
 	private SimpleObject parseObs(Obs obs, Locale locale) {
-        if (obs.getConcept() != null) {
-            //TODO HibernateUtil.getRealObjectFromProxy(obs.getConcept()) should be moved to a better place in the future,
-            //If we remove it, the concept type will never be an instanceof ConceptNumeric
-            Concept concept = HibernateUtil.getRealObjectFromProxy(obs.getConcept());
-            if (concept instanceof ConceptNumeric) {
+        if (obs.getConcept() != null && obs.getConcept().isNumeric()) {
+                //TODO HibernateUtil.getRealObjectFromProxy(obs.getConcept()) should be moved to a better place in the future,
+                //If we remove it, the concept type will never be an instanceof ConceptNumeric
+                Concept concept = HibernateUtil.getRealObjectFromProxy(obs.getConcept());
                 obs.setConcept(concept);
-            }
         }
         if ("org.openmrs.Location".equals(obs.getComment())) {
             return (parseObsWithLocationAnswer(obs, locationService.getLocation(Integer.valueOf(obs.getValueText()))));

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -128,11 +128,11 @@ public class ParserEncounterIntoSimpleObjects {
 	}
 	
 	private SimpleObject parseObs(Obs obs, Locale locale) {
-        if (obs.getConcept() != null && obs.getConcept().isNumeric()) {
+        Concept concept = obs.getConcept();
+        if (concept != null && concept.isNumeric()) {
                 //TODO HibernateUtil.getRealObjectFromProxy(obs.getConcept()) should be moved to a better place in the future,
                 //If we remove it, the concept type will never be an instanceof ConceptNumeric
-                Concept concept = HibernateUtil.getRealObjectFromProxy(obs.getConcept());
-                obs.setConcept(concept);
+                obs.setConcept(HibernateUtil.getRealObjectFromProxy(concept));
         }
         if ("org.openmrs.Location".equals(obs.getComment())) {
             return (parseObsWithLocationAnswer(obs, locationService.getLocation(Integer.valueOf(obs.getValueText()))));
@@ -140,7 +140,7 @@ public class ParserEncounterIntoSimpleObjects {
         else {
             SimpleObject simpleObject = SimpleObject.create("obsId", obs.getObsId());
 
-            simpleObject.put("question", capitalizeString(uiUtils.format(obs.getConcept())));
+            simpleObject.put("question", capitalizeString(uiUtils.format(concept)));
             simpleObject.put("answer", uiUtils.format(obs));
             return simpleObject;
         }

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -17,8 +17,11 @@ import org.openmrs.Encounter;
 import org.openmrs.Location;
 import org.openmrs.Obs;
 import org.openmrs.Order;
+import org.openmrs.Concept;
+import org.openmrs.ConceptNumeric;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.LocationService;
+import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.module.emrapi.EmrApiProperties;
 import org.openmrs.module.emrapi.diagnosis.Diagnosis;
 import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
@@ -129,8 +132,13 @@ public class ParserEncounterIntoSimpleObjects {
 	}
 	
 	private SimpleObject parseObs(Obs obs, Locale locale) {
-        if(obs.getConcept() != null && obs.getConcept().isNumeric()){
-            obs.setConcept(this.conceptService.getConceptNumeric(obs.getConcept().getConceptId()));
+        if (obs.getConcept() != null) {
+            //TODO HibernateUtil.getRealObjectFromProxy(obs.getConcept()) should be moved to a better place in the future,
+            //If we remove it, the concept type will never be an instanceof ConceptNumeric
+            Concept concept = HibernateUtil.getRealObjectFromProxy(obs.getConcept());
+            if (concept instanceof ConceptNumeric) {
+                obs.setConcept(concept);
+            }
         }
         if ("org.openmrs.Location".equals(obs.getComment())) {
             return (parseObsWithLocationAnswer(obs, locationService.getLocation(Integer.valueOf(obs.getValueText()))));

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjects.java
@@ -140,7 +140,7 @@ public class ParserEncounterIntoSimpleObjects {
         else {
             SimpleObject simpleObject = SimpleObject.create("obsId", obs.getObsId());
 
-            simpleObject.put("question", capitalizeString(uiUtils.format(concept)));
+            simpleObject.put("question", capitalizeString(uiUtils.format(obs.getConcept())));
             simpleObject.put("answer", uiUtils.format(obs));
             return simpleObject;
         }

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDetailsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDetailsFragmentController.java
@@ -26,6 +26,7 @@ import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.VisitService;
+import org.openmrs.api.ConceptService;
 import org.openmrs.module.appframework.context.AppContextModel;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.service.AppFrameworkService;
@@ -174,11 +175,12 @@ public class VisitDetailsFragmentController {
    public SimpleObject getEncounterDetails(@RequestParam("encounterId") Encounter encounter,
          @SpringBean("emrApiProperties") EmrApiProperties emrApiProperties,
          @SpringBean("locationService") LocationService locationService,
+         @SpringBean("conceptService") ConceptService conceptService,
          @SpringBean("dispositionService") DispositionService dispositionService,
          UiUtils uiUtils) {
 
       ParserEncounterIntoSimpleObjects parserEncounter = new ParserEncounterIntoSimpleObjects(encounter, uiUtils,
-            emrApiProperties, locationService, dispositionService);
+            emrApiProperties, locationService, conceptService,  dispositionService);
 
       ParsedObs parsedObs = parserEncounter.parseObservations(uiUtils.getLocale());
       List<SimpleObject> orders = parserEncounter.parseOrders();

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDetailsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDetailsFragmentController.java
@@ -26,7 +26,6 @@ import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.VisitService;
-import org.openmrs.api.ConceptService;
 import org.openmrs.module.appframework.context.AppContextModel;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.service.AppFrameworkService;
@@ -175,12 +174,11 @@ public class VisitDetailsFragmentController {
    public SimpleObject getEncounterDetails(@RequestParam("encounterId") Encounter encounter,
          @SpringBean("emrApiProperties") EmrApiProperties emrApiProperties,
          @SpringBean("locationService") LocationService locationService,
-         @SpringBean("conceptService") ConceptService conceptService,
          @SpringBean("dispositionService") DispositionService dispositionService,
          UiUtils uiUtils) {
 
       ParserEncounterIntoSimpleObjects parserEncounter = new ParserEncounterIntoSimpleObjects(encounter, uiUtils,
-            emrApiProperties, locationService, conceptService,  dispositionService);
+            emrApiProperties, locationService, dispositionService);
 
       ParsedObs parsedObs = parserEncounter.parseObservations(uiUtils.getLocale());
       List<SimpleObject> orders = parserEncounter.parseOrders();

--- a/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
@@ -64,7 +64,7 @@
 
     {{ _.each(observations, function(observation) { }}
         {{ if(observation.answer != null) {}}
-            <p><small>{{- observation.question}}</small><span>{{- observation.integerNumber ? parseInt(observation.answer) : observation.answer}}</span></p>
+            <p><small>{{- observation.question}}</small><span>{{- observation.isIntegerValue ? parseInt(observation.answer) : observation.answer}}</span></p>
         {{}}}
     {{ }); }}
 

--- a/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
@@ -64,7 +64,7 @@
 
     {{ _.each(observations, function(observation) { }}
         {{ if(observation.answer != null) {}}
-            <p><small>{{- observation.question}}</small><span>{{- observation.isIntegerValue ? parseInt(observation.answer) : observation.answer}}</span></p>
+            <p><small>{{- observation.question}}</small><span>{{- observation.answer}}</span></p>
         {{}}}
     {{ }); }}
 

--- a/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/encountertemplate/defaultEncounterTemplate.gsp
@@ -64,7 +64,7 @@
 
     {{ _.each(observations, function(observation) { }}
         {{ if(observation.answer != null) {}}
-            <p><small>{{- observation.question}}</small><span>{{- observation.answer}}</span></p>
+            <p><small>{{- observation.question}}</small><span>{{- observation.integerNumber ? parseInt(observation.answer) : observation.answer}}</span></p>
         {{}}}
     {{ }); }}
 

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
@@ -301,7 +301,7 @@ public class ParserEncounterIntoSimpleObjectsTest {
 		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) valueText));
 	}
 	@Test
-	public void testParsingNumericDataTypeWithAllowDecimalToSimpleObs() throws Exception {
+	public void testParsingNumericObsShouldHandleAllowDecimal() throws Exception {
 		ConceptDatatype numericDatatype  = new ConceptDatatype() ;
 		numericDatatype.setName("Numeric");
 		numericDatatype.setHl7Abbreviation("NM");
@@ -324,7 +324,7 @@ public class ParserEncounterIntoSimpleObjectsTest {
 	}
 
 	@Test
-	public void testParsingNumericDataTypeWithAllowDecimalAsFalseToSimpleObs() throws Exception {
+	public void testParsingNumericObsShouldHandleDisallowDecimal() throws Exception {
 		ConceptDatatype numericDatatype  = new ConceptDatatype() ;
 		numericDatatype.setName("Numeric");
 		numericDatatype.setHl7Abbreviation("NM");

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
@@ -321,11 +321,13 @@ public class ParserEncounterIntoSimpleObjectsTest {
 		ParsedObs parsed = parser.parseObservations(Locale.ENGLISH);
 		assertThat(parsed.getObs().size(), is(1));
 		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) "2.0"));
+		assertThat(path(parsed.getObs(), 0, "isIntegerValue"), is((Object) false));
+
 	}
 
 	@Test
 	public void testParsingNumericObsShouldHandleDisallowDecimal() throws Exception {
-		ConceptDatatype numericDatatype  = new ConceptDatatype() ;
+		ConceptDatatype numericDatatype  = new ConceptDatatype();
 		numericDatatype.setName("Numeric");
 		numericDatatype.setHl7Abbreviation("NM");
 
@@ -344,6 +346,7 @@ public class ParserEncounterIntoSimpleObjectsTest {
 		ParsedObs parsed = parser.parseObservations(Locale.ENGLISH);
 		assertThat(parsed.getObs().size(), is(1));
 		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) "2"));
+		assertThat(path(parsed.getObs(), 0, "isIntegerValue"), is((Object) true));
 	}
 
     @Test

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
@@ -127,7 +127,7 @@ public class ParserEncounterIntoSimpleObjectsTest {
 		uiUtils = testUiUtils;
 
 		encounter = new Encounter();
-		parser = new ParserEncounterIntoSimpleObjects(encounter, uiUtils, emrApiProperties, locationService, conceptService, dispositionService);
+		parser = new ParserEncounterIntoSimpleObjects(encounter, uiUtils, emrApiProperties, locationService, dispositionService);
 	}
 
 	@Test

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
@@ -15,6 +15,7 @@ package org.openmrs.module.coreapps.fragment.controller.visit;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -299,6 +300,28 @@ public class ParserEncounterIntoSimpleObjectsTest {
 		assertThat(path(parsed.getObs(), 0, "question"), is((Object) consultNote));
 		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) valueText));
 	}
+	@Test
+	public void testParsingNumericDataTypeWithAllowDecimalToSimpleObs() throws Exception {
+		ConceptDatatype numericDatatype  = new ConceptDatatype() ;
+		numericDatatype.setName("Numeric");
+		numericDatatype.setHl7Abbreviation("NM");
+
+		ConceptName conceptName = new ConceptName("numericConceptTest" , Locale.ENGLISH);
+		ConceptNumeric conceptNumeric = new ConceptNumeric();
+		conceptNumeric.setId(1000);
+		conceptNumeric.addName(conceptName);
+		conceptNumeric.setUuid("uuid");
+		conceptNumeric.setAllowDecimal(true);
+		conceptNumeric.setDatatype(numericDatatype);
+
+		Double numericValue = 2.0;
+
+		when(conceptService.getConceptNumeric(eq(1000))).thenReturn(conceptNumeric);
+		encounter.addObs(new ObsBuilder().setConcept(conceptNumeric).setValue(numericValue).get());
+		ParsedObs parsed = parser.parseObservations(Locale.ENGLISH);
+		assertThat(parsed.getObs().size(), is(1));
+		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) "2.0"));
+	}
 
 	@Test
 	public void testParsingNumericDataTypeWithAllowDecimalAsFalseToSimpleObs() throws Exception {
@@ -316,7 +339,7 @@ public class ParserEncounterIntoSimpleObjectsTest {
 
 		Double numericValue = 2.0;
 
-		when(conceptService.getConceptNumeric(anyInt())).thenReturn(conceptNumeric);
+		when(conceptService.getConceptNumeric(eq(1000))).thenReturn(conceptNumeric);
 		encounter.addObs(new ObsBuilder().setConcept(conceptNumeric).setValue(numericValue).get());
 		ParsedObs parsed = parser.parseObservations(Locale.ENGLISH);
 		assertThat(parsed.getObs().size(), is(1));

--- a/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
+++ b/omod/src/test/java/org/openmrs/module/coreapps/fragment/controller/visit/ParserEncounterIntoSimpleObjectsTest.java
@@ -15,9 +15,7 @@ package org.openmrs.module.coreapps.fragment.controller.visit;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,8 +35,6 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openmrs.Concept;
-import org.openmrs.ConceptName;
-import org.openmrs.ConceptNumeric;
 import org.openmrs.ConceptClass;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.Encounter;
@@ -299,54 +295,6 @@ public class ParserEncounterIntoSimpleObjectsTest {
 		assertThat(parsed.getObs().size(), is(1));
 		assertThat(path(parsed.getObs(), 0, "question"), is((Object) consultNote));
 		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) valueText));
-	}
-	@Test
-	public void testParsingNumericObsShouldHandleAllowDecimal() throws Exception {
-		ConceptDatatype numericDatatype  = new ConceptDatatype() ;
-		numericDatatype.setName("Numeric");
-		numericDatatype.setHl7Abbreviation("NM");
-
-		ConceptName conceptName = new ConceptName("numericConceptTest" , Locale.ENGLISH);
-		ConceptNumeric conceptNumeric = new ConceptNumeric();
-		conceptNumeric.setId(1000);
-		conceptNumeric.addName(conceptName);
-		conceptNumeric.setUuid("uuid");
-		conceptNumeric.setAllowDecimal(true);
-		conceptNumeric.setDatatype(numericDatatype);
-
-		Double numericValue = 2.0;
-
-		when(conceptService.getConceptNumeric(eq(1000))).thenReturn(conceptNumeric);
-		encounter.addObs(new ObsBuilder().setConcept(conceptNumeric).setValue(numericValue).get());
-		ParsedObs parsed = parser.parseObservations(Locale.ENGLISH);
-		assertThat(parsed.getObs().size(), is(1));
-		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) "2.0"));
-		assertThat(path(parsed.getObs(), 0, "isIntegerValue"), is((Object) false));
-
-	}
-
-	@Test
-	public void testParsingNumericObsShouldHandleDisallowDecimal() throws Exception {
-		ConceptDatatype numericDatatype  = new ConceptDatatype();
-		numericDatatype.setName("Numeric");
-		numericDatatype.setHl7Abbreviation("NM");
-
-		ConceptName conceptName = new ConceptName("numericConceptTest" , Locale.ENGLISH);
-		ConceptNumeric conceptNumeric = new ConceptNumeric();
-		conceptNumeric.setId(1000);
-		conceptNumeric.addName(conceptName);
-		conceptNumeric.setUuid("uuid");
-		conceptNumeric.setAllowDecimal(false);
-		conceptNumeric.setDatatype(numericDatatype);
-
-		Double numericValue = 2.0;
-
-		when(conceptService.getConceptNumeric(eq(1000))).thenReturn(conceptNumeric);
-		encounter.addObs(new ObsBuilder().setConcept(conceptNumeric).setValue(numericValue).get());
-		ParsedObs parsed = parser.parseObservations(Locale.ENGLISH);
-		assertThat(parsed.getObs().size(), is(1));
-		assertThat(path(parsed.getObs(), 0, "answer"), is((Object) "2"));
-		assertThat(path(parsed.getObs(), 0, "isIntegerValue"), is((Object) true));
 	}
 
     @Test


### PR DESCRIPTION
**Ticket:**

https://issues.openmrs.org/browse/RA-1945

**What I have done:**

When ParserEncounterIntoSimpleObjects if we are dealing with an concept that is `numeric` we will cast to `conceptNumeric`