### PR TITLE
RA-1954 - Add GP DECEASED_DATE_USING_TIME 

### DIFF
--- a/api/src/main/java/org/openmrs/module/coreapps/CoreAppsConstants.java
+++ b/api/src/main/java/org/openmrs/module/coreapps/CoreAppsConstants.java
@@ -58,4 +58,6 @@ public class CoreAppsConstants {
    public static final String GLOBAL_PROPERTY_CONDITIONS_CRITERIA = "coreapps.conditionListClasses";
 
    public static final String DEFAULT_CODING_SOURCE = "ICD-10-WHO";
+
+   public static final String DECEASED_DATE_USING_TIME = "coreapps.deceasedDateUsingTime";
 }

--- a/api/src/main/java/org/openmrs/module/coreapps/CoreAppsConstants.java
+++ b/api/src/main/java/org/openmrs/module/coreapps/CoreAppsConstants.java
@@ -59,5 +59,5 @@ public class CoreAppsConstants {
 
    public static final String DEFAULT_CODING_SOURCE = "ICD-10-WHO";
 
-   public static final String DECEASED_DATE_USING_TIME = "coreapps.deceasedDateUsingTime";
+   public static final String GP_DECEASED_DATE_USING_TIME = "coreapps.deceasedDateUsingTime";
 }

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MarkPatientDeadPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MarkPatientDeadPageController.java
@@ -11,6 +11,7 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.coreapps.CoreAppsConstants;
 import org.openmrs.module.emrapi.EmrApiProperties;
 import org.openmrs.module.emrapi.exitfromcare.ExitFromCareService;
 import org.openmrs.ui.framework.SimpleObject;
@@ -48,7 +49,7 @@ public class MarkPatientDeadPageController {
         pageModel.put("defaultDeathDate", defaultDeathDate);
         // if the getPatientDied property is configured, the ExitFromCare service will close/reopen patient programs when marking a patient dead/not dead
         pageModel.put("renderProgramWarning", emrApiProperties.getPatientDiedConcept() != null);
-
+        pageModel.put("deceasedDateTimeComponent", Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.DECEASED_DATE_USING_TIME , "false"));
         String conceptId = Context.getAdministrationService().getGlobalProperty("concept.causeOfDeath");
 
         if (conceptId != null) {

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MarkPatientDeadPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/MarkPatientDeadPageController.java
@@ -49,7 +49,7 @@ public class MarkPatientDeadPageController {
         pageModel.put("defaultDeathDate", defaultDeathDate);
         // if the getPatientDied property is configured, the ExitFromCare service will close/reopen patient programs when marking a patient dead/not dead
         pageModel.put("renderProgramWarning", emrApiProperties.getPatientDiedConcept() != null);
-        pageModel.put("deceasedDateTimeComponent", Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.DECEASED_DATE_USING_TIME , "false"));
+        pageModel.put("includesTime", Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.GP_DECEASED_DATE_USING_TIME , "false"));
         String conceptId = Context.getAdministrationService().getGlobalProperty("concept.causeOfDeath");
 
         if (conceptId != null) {

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -294,6 +294,14 @@
         </description>
     </globalProperty>
 
+    <globalProperty>
+        <property>coreapps.deceasedDateUsingTime</property>
+        <defaultValue>false</defaultValue>
+        <description>
+            Deceased date using time component or only date.
+        </description>
+    </globalProperty>
+
     <privilege>
         <name>Task: coreapps.editRelationships</name>
         <description>Able to edit relationships</description>

--- a/omod/src/main/webapp/pages/markPatientDead.gsp
+++ b/omod/src/main/webapp/pages/markPatientDead.gsp
@@ -127,7 +127,7 @@ ${ui.includeFragment("coreapps", "patientHeader", [patient: patient])}
                         formFieldName: "deathDate",
                         left         : true,
                         defaultDate  : patient?.getDeathDate() ?: defaultDeathDate ?: null,
-                        useTime      : deceasedDateTimeComponent,
+                        useTime      : includesTime,
                         showEstimated: false,
                         initialValue : lastVisitDate ?:new Date(),
                         startDate    : lastVisitDate?:birthDate,

--- a/omod/src/main/webapp/pages/markPatientDead.gsp
+++ b/omod/src/main/webapp/pages/markPatientDead.gsp
@@ -127,7 +127,7 @@ ${ui.includeFragment("coreapps", "patientHeader", [patient: patient])}
                         formFieldName: "deathDate",
                         left         : true,
                         defaultDate  : patient?.getDeathDate() ?: defaultDeathDate ?: null,
-                        useTime      : false,
+                        useTime      : deceasedDateTimeComponent,
                         showEstimated: false,
                         initialValue : lastVisitDate ?:new Date(),
                         startDate    : lastVisitDate?:birthDate,


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1954

Create a global property `DECEASED_DATE_USING_TIME` that allows choosing if we want the Decease Date datepicker to have a time component.


If it's true we can select date + time.

If it's not true, we can only select date.

