### PR TITLE
UIFR-220 - Bump UiFrameworkVersion version to 3.22.0 to be able to use a new method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <emrapiVersion>1.32.0</emrapiVersion>
-        <uiframeworkVersion>3.21.0</uiframeworkVersion>
+        <uiframeworkVersion>3.22.0</uiframeworkVersion>
         <eventVersion>2.8.0</eventVersion>
         <htmlformentryVersion>3.3.0</htmlformentryVersion>
         <appuiVersion>1.7</appuiVersion>


### PR DESCRIPTION
UIFR-220 - Bump UiFrameworkVersion version to 3.22.0 to be able to use a new method from UiFramework