### PR TITLE
RA-1968: Add all patient encounters to context model

### DIFF
--- a/api/src/main/java/org/openmrs/module/coreapps/contextmodel/PatientEncounterContextModel.java
+++ b/api/src/main/java/org/openmrs/module/coreapps/contextmodel/PatientEncounterContextModel.java
@@ -1,0 +1,31 @@
+package org.openmrs.module.coreapps.contextmodel;
+
+import org.openmrs.Encounter;
+
+import java.util.Date;
+
+public class PatientEncounterContextModel {
+
+    Date encounterDatetime;
+    String encounterTypeName;
+    String encounterTypeUuid;
+
+    public PatientEncounterContextModel(Encounter encounter) {
+        this.encounterDatetime = encounter.getEncounterDatetime();
+        this.encounterTypeName = encounter.getEncounterType().getName();
+        this.encounterTypeUuid = encounter.getEncounterType().getUuid();
+    }
+
+    public Date getEncounterDatetime() {
+        return encounterDatetime;
+    }
+
+    public String getEncounterTypeName() {
+        return encounterTypeName;
+    }
+
+    public String getEncounterTypeUuid() {
+        return encounterTypeUuid;
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/clinicianfacing/VisitsSectionFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/clinicianfacing/VisitsSectionFragmentController.java
@@ -139,8 +139,11 @@ public class VisitsSectionFragmentController {
 		}
 
 		Map<VisitDomainWrapper, String> recentVisitsWithLinks = new LinkedHashMap<VisitDomainWrapper, String>();
+
+		if (!recentVisits.isEmpty()) {
+			contextModel.put("visit", new VisitContextModel(recentVisits.get(recentVisits.size() - 1)));
+		}
 		for (VisitDomainWrapper recentVisit : recentVisits) {
-			contextModel.put("visit", new VisitContextModel(recentVisit));
             // since the "recentVisit" isn't part of the context module, we bind it first to the visit url, before doing the handlebars binding against the context
 			recentVisitsWithLinks.put(recentVisit, templateFactory.handlebars(ui.urlBind(visitsPageWithSpecificVisitUrl, recentVisit.getVisit()), contextModel));
 		}

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/clinicianfacing/PatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/clinicianfacing/PatientPageController.java
@@ -30,6 +30,7 @@ import org.openmrs.module.appframework.context.AppContextModel;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.openmrs.module.coreapps.contextmodel.PatientEncounterContextModel;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.coreapps.CoreAppsConstants;
@@ -110,6 +111,11 @@ public class PatientPageController {
             encounterTypes.add(encounter.getEncounterType());
         }
         contextModel.put("encounterTypes", ConversionUtil.convertToRepresentation(encounterTypes, Representation.DEFAULT));
+       ArrayList<PatientEncounterContextModel> encountersModel = new ArrayList<PatientEncounterContextModel>();
+       for (Encounter encounter : encounters) {
+           encountersModel.add(new PatientEncounterContextModel(encounter));
+       }
+       contextModel.put("encounters", encountersModel);
 
         List<Program> programs = new ArrayList<Program>();
         List<PatientProgram> patientPrograms = Context.getProgramWorkflowService().getPatientPrograms(patient, null, null, null, null, null, false);

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/clinicianfacing/PatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/clinicianfacing/PatientPageController.java
@@ -106,16 +106,14 @@ public class PatientPageController {
         contextModel.put("visit", activeVisit == null ? null : new VisitContextModel(activeVisit));
 
         List<EncounterType> encounterTypes = new ArrayList<EncounterType>();
+        ArrayList<PatientEncounterContextModel> encountersModel = new ArrayList<PatientEncounterContextModel>();
         List<Encounter> encounters = encounterService.getEncountersByPatient(patient);
         for (Encounter encounter : encounters) {
             encounterTypes.add(encounter.getEncounterType());
+            encountersModel.add(new PatientEncounterContextModel(encounter));
         }
         contextModel.put("encounterTypes", ConversionUtil.convertToRepresentation(encounterTypes, Representation.DEFAULT));
-       ArrayList<PatientEncounterContextModel> encountersModel = new ArrayList<PatientEncounterContextModel>();
-       for (Encounter encounter : encounters) {
-           encountersModel.add(new PatientEncounterContextModel(encounter));
-       }
-       contextModel.put("encounters", encountersModel);
+        contextModel.put("encounters", encountersModel);
 
         List<Program> programs = new ArrayList<Program>();
         List<PatientProgram> patientPrograms = Context.getProgramWorkflowService().getPatientPrograms(patient, null, null, null, null, null, false);

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/patientdashboard/PatientDashboardPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/patientdashboard/PatientDashboardPageController.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.openmrs.Encounter;
+import org.openmrs.EncounterType;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
@@ -36,6 +37,8 @@ import org.openmrs.module.emrapi.adt.AdtService;
 import org.openmrs.module.emrapi.event.ApplicationEventService;
 import org.openmrs.module.emrapi.patient.PatientDomainWrapper;
 import org.openmrs.module.emrapi.visit.VisitDomainWrapper;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.ui.framework.annotation.InjectBeans;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.page.PageModel;
@@ -91,11 +94,16 @@ public class PatientDashboardPageController {
       AppContextModel contextModel = sessionContext.generateAppContextModel();
       contextModel.put("patient", new PatientContextModel(patient));
       contextModel.put("visit", activeVisit == null ? null : new VisitContextModel(activeVisit));
+
+      List<EncounterType> encounterTypes = new ArrayList<EncounterType>();
       ArrayList<PatientEncounterContextModel> encountersModel = new ArrayList<PatientEncounterContextModel>();
       for (Encounter encounter : encounters) {
+         encounterTypes.add(encounter.getEncounterType());
          encountersModel.add(new PatientEncounterContextModel(encounter));
       }
+      contextModel.put("encounterTypes", ConversionUtil.convertToRepresentation(encounterTypes, Representation.DEFAULT));
       contextModel.put("encounters", encountersModel);
+
       model.addAttribute("appContextModel", contextModel);
 
       List<Extension> overallActions = appFrameworkService.getExtensionsForCurrentUser("patientDashboard.overallActions", contextModel);

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/patientdashboard/PatientDashboardPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/patientdashboard/PatientDashboardPageController.java
@@ -13,9 +13,11 @@
  */
 package org.openmrs.module.coreapps.page.controller.patientdashboard;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.openmrs.Encounter;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
@@ -28,6 +30,7 @@ import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.coreapps.CoreAppsConstants;
 import org.openmrs.module.coreapps.CoreAppsProperties;
 import org.openmrs.module.coreapps.contextmodel.PatientContextModel;
+import org.openmrs.module.coreapps.contextmodel.PatientEncounterContextModel;
 import org.openmrs.module.coreapps.contextmodel.VisitContextModel;
 import org.openmrs.module.emrapi.adt.AdtService;
 import org.openmrs.module.emrapi.event.ApplicationEventService;
@@ -83,10 +86,16 @@ public class PatientDashboardPageController {
             .getExtensionsForCurrentUser(CoreAppsConstants.ENCOUNTER_TEMPLATE_EXTENSION);
       model.addAttribute("encounterTemplateExtensions", encounterTemplateExtensions);
 
+      List<Encounter> encounters = Context.getEncounterService().getEncountersByPatient(patient);
 
       AppContextModel contextModel = sessionContext.generateAppContextModel();
       contextModel.put("patient", new PatientContextModel(patient));
       contextModel.put("visit", activeVisit == null ? null : new VisitContextModel(activeVisit));
+      ArrayList<PatientEncounterContextModel> encountersModel = new ArrayList<PatientEncounterContextModel>();
+      for (Encounter encounter : encounters) {
+         encountersModel.add(new PatientEncounterContextModel(encounter));
+      }
+      contextModel.put("encounters", encountersModel);
       model.addAttribute("appContextModel", contextModel);
 
       List<Extension> overallActions = appFrameworkService.getExtensionsForCurrentUser("patientDashboard.overallActions", contextModel);


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-1968

This allows extension `require`s to refer to a patient's historical encounters. Demonstrated here with "Covid 19 Note d'Admission"

![previous-encounter](https://user-images.githubusercontent.com/1031876/139347857-a891d877-ac67-4d66-83a9-ea33d07c78bf.gif)

