### PR TITLE
#RA-1983 - Refresh component after data is fetched

### DIFF
--- a/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsacrossencounters/obsacrossencounters.controller.js
@@ -1,8 +1,8 @@
 export default class ObsAcrossEncountersController {
-  constructor($q, $filter, openmrsRest, openmrsTranslate, widgetsCommons) {
+  constructor($scope, $q, $filter, openmrsRest, openmrsTranslate, widgetsCommons) {
     'ngInject';
 
-    Object.assign(this, {$q, $filter, openmrsRest, openmrsTranslate, widgetsCommons});
+    Object.assign(this, {$scope, $q, $filter, openmrsRest, openmrsTranslate, widgetsCommons});
   }
 
   $onInit() {
@@ -143,6 +143,7 @@ export default class ObsAcrossEncountersController {
         row.push(obsArray);
       }
     }
+    this.$scope.$apply();
   }
 
   isRetired(obs) {


### PR DESCRIPTION
The issue (https://issues.openmrs.org/browse/RA-1983):

ObsAcrossEncounters widgets might not show information or show only a small fraction

How to replicate:
1) Go to a page containing multiple ObsAcrossEncounters widgets (These should contain information)
2) Go into the browser dev tools -> Network tab -> make sure "Disable cache" is unchecked 
3) Refresh the page

Solution:
Add scope to component 
And refresh scope after all data has been fetched 