### PR TITLE
Use openmrs-module-coreapps module when setting up apps on PRs

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,14 +5,14 @@
       "url": "https://github.com/mars/create-react-app-buildpack.git"
     }
   ],
-  "description": "QA Framework for OpenMRS",
+  "description": "Core Apps for OpenMRS",
   "env": {},
   "formation": {
     "web": {
       "quantity": 1
     }
   },
-  "name": "openmrs-contrib-qaframework",
+  "name": "openmrs-module-coreapps",
   "scripts": {
   },
   "stack": "heroku-20"


### PR DESCRIPTION
When setting up apps on PRs, app.json file should use openmrs-module-coreapps not openmrs-contrib-qaframework.