### PR TITLE
RA-1985 - Allow changing visit time dynamically

### DIFF
--- a/api/src/main/java/org/openmrs/module/coreapps/CoreAppsConstants.java
+++ b/api/src/main/java/org/openmrs/module/coreapps/CoreAppsConstants.java
@@ -60,4 +60,6 @@ public class CoreAppsConstants {
    public static final String DEFAULT_CODING_SOURCE = "ICD-10-WHO";
 
    public static final String GP_DECEASED_DATE_USING_TIME = "coreapps.deceasedDateUsingTime";
+
+   public static final String GP_ALLOW_CHANGING_VISIT_TIME = "coreapps.allowChangingVisitTime";
 }

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.module.coreapps.fragment.controller.visit;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.joda.time.DateTime;
 import org.openmrs.Visit;
 import org.openmrs.api.VisitService;
@@ -39,7 +40,7 @@ public class VisitDatesFragmentController {
                                             @RequestParam(value="stopDate", required = false) Date stopDate,
                                             HttpServletRequest request, UiUtils ui) {
 
-        Boolean allowChangingVisitTime = new Boolean(Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.GP_ALLOW_CHANGING_VISIT_TIME));
+        boolean allowChangingVisitTime = BooleanUtils.toBoolean(Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.GP_ALLOW_CHANGING_VISIT_TIME));
 
         if (!allowChangingVisitTime && !isSameDay(startDate, visit.getStartDatetime())) {
             visit.setStartDatetime(new DateTime(startDate).toDateMidnight().toDate());

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
@@ -44,7 +44,7 @@ public class VisitDatesFragmentController {
 
         if (!allowChangingVisitTime && !isSameDay(startDate, visit.getStartDatetime())) {
             visit.setStartDatetime(new DateTime(startDate).toDateMidnight().toDate());
-        }else{
+        } else if (allowChangingVisitTime && !isSameDay(startDate, visit.getStartDatetime())){
             visit.setStartDatetime(new DateTime(startDate).toDate());
         }
 

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
@@ -16,7 +16,9 @@ package org.openmrs.module.coreapps.fragment.controller.visit;
 import org.joda.time.DateTime;
 import org.openmrs.Visit;
 import org.openmrs.api.VisitService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.appui.AppUiConstants;
+import org.openmrs.module.coreapps.CoreAppsConstants;
 import org.openmrs.ui.framework.SimpleObject;
 import org.openmrs.ui.framework.UiUtils;
 import org.openmrs.ui.framework.annotation.SpringBean;
@@ -37,9 +39,12 @@ public class VisitDatesFragmentController {
                                             @RequestParam(value="stopDate", required = false) Date stopDate,
                                             HttpServletRequest request, UiUtils ui) {
 
+        Boolean allowChangingVisitTime = new Boolean(Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.GP_ALLOW_CHANGING_VISIT_TIME));
 
-        if (!isSameDay(startDate, visit.getStartDatetime())) {
+        if (!allowChangingVisitTime && !isSameDay(startDate, visit.getStartDatetime())) {
             visit.setStartDatetime(new DateTime(startDate).toDateMidnight().toDate());
+        }else{
+            visit.setStartDatetime(new DateTime(startDate).toDate());
         }
 
         if ( (stopDate!=null) && !isSameDay(stopDate, visit.getStopDatetime())) {

--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/visit/VisitDatesFragmentController.java
@@ -42,11 +42,14 @@ public class VisitDatesFragmentController {
 
         boolean allowChangingVisitTime = BooleanUtils.toBoolean(Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.GP_ALLOW_CHANGING_VISIT_TIME));
 
-        if (!allowChangingVisitTime && !isSameDay(startDate, visit.getStartDatetime())) {
-            visit.setStartDatetime(new DateTime(startDate).toDateMidnight().toDate());
-        } else if (allowChangingVisitTime && !isSameDay(startDate, visit.getStartDatetime())){
-            visit.setStartDatetime(new DateTime(startDate).toDate());
+        if (!isSameDay(startDate, visit.getStartDatetime())) {
+            if(!allowChangingVisitTime){
+                visit.setStartDatetime(new DateTime(startDate).toDateMidnight().toDate());
+            }else{
+                visit.setStartDatetime(new DateTime(startDate).toDate());
+            }
         }
+
 
         if ( (stopDate!=null) && !isSameDay(stopDate, visit.getStopDatetime())) {
             Date now = new DateTime().toDate();

--- a/omod/src/main/java/org/openmrs/module/coreapps/page/controller/patientdashboard/PatientDashboardPageController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/page/controller/patientdashboard/PatientDashboardPageController.java
@@ -128,6 +128,8 @@ public class PatientDashboardPageController {
 
       model.addAttribute("userId", sessionContext.getCurrentUser().getUserId());
 
+      model.addAttribute("allowChangingVisitTime", Context.getAdministrationService().getGlobalProperty(CoreAppsConstants.GP_ALLOW_CHANGING_VISIT_TIME));
+
       return null;
    }
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -302,6 +302,14 @@
         </description>
     </globalProperty>
 
+    <globalProperty>
+        <property>coreapps.allowChangingVisitTime</property>
+        <defaultValue>true</defaultValue>
+        <description>
+            Be able to change the start hour of a visit.
+        </description>
+    </globalProperty>
+
     <privilege>
         <name>Task: coreapps.editRelationships</name>
         <description>Able to edit relationships</description>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -304,7 +304,7 @@
 
     <globalProperty>
         <property>coreapps.allowChangingVisitTime</property>
-        <defaultValue>true</defaultValue>
+        <defaultValue>false</defaultValue>
         <description>
             Be able to change the start hour of a visit.
         </description>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -306,7 +306,7 @@
         <property>coreapps.allowChangingVisitTime</property>
         <defaultValue>false</defaultValue>
         <description>
-            Be able to change the start hour of a visit.
+            Be able to change the start time of a visit.
         </description>
     </globalProperty>
 

--- a/omod/src/main/webapp/fragments/patientdashboard/editVisitDatesDialog.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/editVisitDatesDialog.gsp
@@ -15,7 +15,7 @@
                         id: "startDate" + config.visitId,
                         formFieldName: "startDate",
                         label:"",
-                        useTime: false,
+                        useTime: config.allowChangingVisitTime,
                         startDate: config.startDateLowerLimit,
                         endDate: config.startDateUpperLimit,
                         defaultDate: config.defaultStartDate

--- a/omod/src/main/webapp/fragments/patientdashboard/visits.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/visits.gsp
@@ -112,6 +112,7 @@
         </li>
         ${ ui.includeFragment("coreapps", "patientdashboard/editVisitDatesDialog", [
                 visitId: wrapper.visit.visitId,
+                allowChangingVisitTime: allowChangingVisitTime,
                 endDateUpperLimit: idx == 0 ? editDateFormat.format(new Date()) : editDateFormat.format(org.apache.commons.lang.time.DateUtils.addDays(visits[idx - 1].startDatetime, -1)),
                 endDateLowerLimit: editDateFormat.format(wrapper.mostRecentEncounter == null ? wrapper.startDatetime : wrapper.mostRecentEncounter.encounterDatetime),
                 startDateLowerLimit: (idx + 1 == visits.size || visits[idx + 1].stopDatetime == null) ? null : editDateFormat.format(org.apache.commons.lang.time.DateUtils.addDays(visits[idx + 1].stopDatetime, 1)),


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/RA-1985

If a user creates a visit, and later on decide to edit said visit.
Currently its no possible to change time.  

The proposal is allowing the visit time to be changed
(According with the needs of the implementation)

Solution found: 
Adding global property to enable / disable useTime in the dateTimePicker