### PR TITLE
RA-1678 Condition List: Problems with time zones

### DIFF
--- a/omod/src/main/webapp/pages/conditionlist/manageCondition.gsp
+++ b/omod/src/main/webapp/pages/conditionlist/manageCondition.gsp
@@ -60,7 +60,8 @@ ${ui.includeFragment("coreapps", "patientHeader", [patient: patient])}
                         datePickerFormat : "yyyy-MM-dd",
                         label            : ui.message('coreapps.conditionui.onsetdate'),
                         useTime          : false,
-                        endDate          : new Date()
+                        endDate          : new Date(),
+                        clearButton      : true
                 ])}
             </li>
             &nbsp;&nbsp;
@@ -70,17 +71,18 @@ ${ui.includeFragment("coreapps", "patientHeader", [patient: patient])}
                         datePickerFormat : "yyyy-MM-dd",
                         label            : ui.message('coreapps.stopDate.label'),
                         useTime          : false,
-                        endDate          : new Date()
+                        endDate          : new Date(),
+                        clearButton      : true
                 ])}
             </li>
             <br/><br/>
             <div id="status" class="horizontal">
                 <p>
-                    <input type="radio" id="status-1" class="condition-status" value="${ui.message('coreapps.conditionui.active.label')}" name="status" ng-model="condition.status"  ng-change="showEndDate()"/>
+                    <input type="radio" id="status-1" class="condition-status" value="ACTIVE" name="status" ng-model="condition.status"  ng-change="showEndDate()"/>
                     <label for="status-1">${ui.message('coreapps.conditionui.active.label')}</label>
                 </p>
                 <p>
-                    <input type="radio" id="status-2" class="condition-status" value="${ui.message('coreapps.conditionui.inactive.label')}" name="status" ng-model="condition.status"  ng-change="showEndDate()"/>
+                    <input type="radio" id="status-2" class="condition-status" value="INACTIVE" name="status" ng-model="condition.status"  ng-change="showEndDate()"/>
                     <label for="status-2">${ui.message('coreapps.conditionui.inactive.label')}</label>
                 </p>
             </div>

--- a/omod/src/main/webapp/pages/conditionlist/manageConditions.gsp
+++ b/omod/src/main/webapp/pages/conditionlist/manageConditions.gsp
@@ -6,6 +6,7 @@
     ui.includeJavascript("uicommons", "angular-resource.min.js")
     ui.includeJavascript("uicommons", "angular-common.js")
     ui.includeJavascript("uicommons", "underscore-min.js")
+    ui.includeJavascript("uicommons", "moment-with-locales.min.js")
 
     ui.includeJavascript("coreapps", "conditionlist/lib/polyfills.js")
     ui.includeJavascript("coreapps", "conditionlist/restful-services/restful-service.js");
@@ -40,7 +41,7 @@ ${ui.includeFragment("coreapps", "patientHeader", [patient: patient])}
 <h2>${ui.message("coreapps.conditionui.manageConditions")}</h2>
 
 <div id="condition" ng-app="conditionsApp" ng-controller="ConditionsController"
-     ng-init="conditions = getConditions('${patient.uuid}')">
+     ng-init="conditions = getConditions('${patient.uuid}'); config = { dateFormat: '${ ui.getJSDateFormat() }', locale: '${ ui.getLocale().getLanguage() }'};">
     <div id="tabs">
         <ul>
             <li>

--- a/omod/src/main/webapp/resources/scripts/conditionlist/common.functions.js
+++ b/omod/src/main/webapp/resources/scripts/conditionlist/common.functions.js
@@ -6,11 +6,9 @@
     CommonFunctions.$inject = ['$filter'];
 
     function CommonFunctions($filter) {
-        var format = 'yyyy-MM-dd';
 
         return {
-            extractUrlArgs: extractUrlArgs,
-            formatDate: formatDate
+            extractUrlArgs: extractUrlArgs
         };
 
         function extractUrlArgs(urlArgs) {
@@ -41,12 +39,6 @@
             }
 
             return urlParams;
-        }
-
-        function formatDate(date) {
-            if (typeof date !== 'undefined' && date !== null) {
-                return ($filter('date')(new Date(date), format));
-            }
         }
     }
 })();

--- a/omod/src/main/webapp/resources/scripts/conditionlist/controllers/condition.controller.js
+++ b/omod/src/main/webapp/resources/scripts/conditionlist/controllers/condition.controller.js
@@ -8,7 +8,7 @@
         var onsetDatePicker;
         var startDateElement;
         var endDatePicker;
-        var endDateElement
+        var endDateElement;
         {
             startDateElement = document.querySelector('[name = "conditionStartDate"]');
             if (startDateElement) {
@@ -33,6 +33,7 @@
         $scope.condition = null;
         $scope.conditionUuid = null;
         $scope.title = '';
+
         const INACTIVE_STATUS = 'INACTIVE';
 
         // this is required inorder to initialize the Restangular service
@@ -62,7 +63,7 @@
                     console.log(emr.message("coreapps.conditionui.updateCondition.error"), error);
                 });
             }
-        }
+        };
 
         self.initCondition = self.initCondition || function () {
             var urlArguments = CommonFunctions.extractUrlArgs(window.location.search);
@@ -73,11 +74,11 @@
             // if we have a conditionUuid, we're editing an existing condition; otherwise, we're creating a new one
             if ($scope.conditionUuid) {
                 self.getCondition($scope.conditionUuid);
-                $scope.title = emr.message("coreapps.conditionui.editCondition")
+                $scope.title = emr.message("coreapps.conditionui.editCondition");
             } else {
-                $scope.title = emr.message("coreapps.conditionui.addNewCondition")
+                $scope.title = emr.message("coreapps.conditionui.addNewCondition");
             }
-        }
+        };
 
         self.getCondition = self.getCondition || function (conditionUuid) {
             if (conditionUuid === null || conditionUuid === undefined) {
@@ -96,7 +97,7 @@
                     console.log(emr.message("coreapps.conditionui.getCondition.failure"), error);
                 });
             }
-        }
+        };
 
         self.displayCondition = self.displayCondition || function () {
             $scope.concept = {
@@ -107,7 +108,7 @@
                 conceptName: {
                     display: $scope.condition.concept.name,
                 }
-            }
+            };
 
             if ($scope.condition.onSetDate) {
                 onsetDatePicker.datetimepicker('setUTCDate', new Date($scope.condition.onSetDate));
@@ -119,19 +120,19 @@
 
             document.getElementById('conceptId-input').disabled = true;
             self.showEndDate();
-        }
+        };
 
         self.showEndDate = self.showEndDate || function () {
             var groups = document.getElementsByClassName("group");
             if ($scope.condition.status === INACTIVE_STATUS) {
                 groups[2].style.visibility = "visible";
                 if ($scope.condition.endDate) {
-                    groups[2].getElementsByTagName("input")[0].value = CommonFunctions.formatDate($scope.condition.endDate);
+                    endDatePicker.datetimepicker('setUTCDate', new Date($scope.condition.endDate));
                 }
             } else {
                 groups[2].style.visibility = "hidden";
             }
-        }
+        };
 
         self.validateCondition = self.validateCondition || function () {
             var concept;
@@ -153,27 +154,35 @@
             }
 
             self.saveCondition();
-        }
+        };
 
         self.getSelectedDate = self.getSelectedDate || function () {
-            return startDateElement.value;
-        }
+            return startDateElement.value ? self.toUTCDate(startDateElement.value) : null;
+        };
 
         self.getEndDate = self.getEndDate || function () {
-            return endDateElement.value;
-        }
+            return endDateElement.value ? self.toUTCDate(endDateElement.value) : null;
+        };
+
+        self.toUTCDate = function(dateString) {
+            var utcDate = null;
+            if (dateString) {
+                utcDate = new Date(dateString);
+                utcDate.setTime(utcDate.getTime() + utcDate.getTimezoneOffset() * 60 * 1000);
+            }
+            return utcDate;
+        };
 
         self.initCondition();
 
         $scope.validateCondition = self.validateCondition;
         $scope.showEndDate = self.showEndDate;
         $scope.getEndDate = self.getEndDate;
-        $scope.formatDate = CommonFunctions.formatDate;
         $scope.getCondition = self.getCondition;
         $scope.displayCondition = self.displayCondition;
     }
 
-    ConditionController.$inject = ['$scope', 'RestfulService', 'CommonFunctions']
+    ConditionController.$inject = ['$scope', 'RestfulService', 'CommonFunctions'];
 
     app.controller('ConditionController', ConditionController);
 })(window.emr);

--- a/omod/src/main/webapp/resources/scripts/conditionlist/controllers/conditions.controller.js
+++ b/omod/src/main/webapp/resources/scripts/conditionlist/controllers/conditions.controller.js
@@ -10,6 +10,7 @@
         $scope.conditions = [];
         $scope.conditionToBeRemoved = null;
         $scope.tabs = ["ACTIVE", "INACTIVE"];
+        $scope.config = {};
 
         // this is required inorder to initialize the RestfulService
         RestfulService.setBaseUrl('/' + OPENMRS_CONTEXT_PATH + '/ws/rest/emrapi');
@@ -34,46 +35,46 @@
                                 return condition.voided === false;
                             });
                         }
-                    })
+                    });
 
                 }, function (error) {
                     console.log(emr.message("coreapps.conditionui.getCondition.failure"), error);
                 });
             }
-        }
+        };
 
         self.activateCondition = self.activateCondition || function (condition) {
             condition.status = "ACTIVE";
             self.saveCondition(condition);
-        }
+        };
 
         self.deactivateCondition = self.deactivateCondition || function (condition) {
             condition.status = "INACTIVE";
             self.saveCondition(condition);
-        }
+        };
 
         self.removeCondition = self.removeCondition || function () {
             var condition = $scope.conditionToBeRemoved;
             condition.voided = true;
             self.saveCondition(condition);
             dialog.style.display = "none";
-        }
+        };
 
         self.redirectToEditCondition = self.redirectToEditCondition || function (baselink, condition) {
             window.location = baselink + 'conditionUuid=' + encodeURIComponent(String(condition.uuid));
-        }
+        };
 
         self.conditionConfirmation = self.conditionConfirmation || function (condition) {
             $scope.conditionToBeRemoved = condition;
             removeConditionMessage.innerHTML = emr.message("coreapps.conditionui.removeCondition.message").replace(
                 "\{0\}", "<b>" + condition.concept.name +  "</b>");
             dialog.style.display = "block";
-        }
+        };
 
         self.cancelDeletion = self.cancelDeletion || function () {
             $scope.conditionToBeRemoved = null;
             dialog.style.display = "none";
-        }
+        };
 
         self.saveCondition = self.saveCondition || function (condition) {
             var idx = $scope.conditions.indexOf(condition);
@@ -94,16 +95,24 @@
                 emr.errorAlert("coreapps.conditionui.updateCondition.failure");
                 console.log(emr.message("coreapps.conditionui.updateCondition.failure"), error);
             });
-        }
+        };
+
+        self.formatDate = self.formatDate || function(date) {
+            if (typeof date !== 'undefined' && date !== null) {
+                var locale = $scope.config.locale ? $scope.config.locale : 'en';
+                var format = $scope.config.format ? $scope.config.format : 'DD MMM YYYY';
+                return moment(date).locale(locale).format(format);
+            }
+        };
 
         // bind functions to scope
         $scope.removeCondition = self.removeCondition;
         $scope.cancelDeletion = self.cancelDeletion;
         $scope.activateCondition = self.activateCondition;
         $scope.deactivateCondition = self.deactivateCondition;
-        $scope.formatDate = CommonFunctions.formatDate;
+        $scope.formatDate = self.formatDate;
         $scope.getConditions = self.getConditions;
-        $scope.conditionConfirmation = self.conditionConfirmation
+        $scope.conditionConfirmation = self.conditionConfirmation;
         $scope.redirectToEditCondition = self.redirectToEditCondition;
     }
 


### PR DESCRIPTION
This PR addresses a number of issues with the Condition List date fields:

Reported issues fixed:
* It fixes RA-1678 such that dates submitted to the server are stored consistently with how they are entered on the client.
* It fixes RA-2012 by enabling the onset and end date input fields to be cleared/unset

Unreported issues fixed:
* Fixes syntax errors in JS causing Jasmine tests to fail
* Fixes bug that prevents marking conditions as inactive if the locale is anything other than English
* Fixes the display of onset and end dates in the condition list table to match refapp localized date formatting. 