### PR TITLE
Program display should not overflow into date display.

### DIFF
--- a/omod/src/main/web/dashboardwidgets/programs/programs.html
+++ b/omod/src/main/web/dashboardwidgets/programs/programs.html
@@ -18,8 +18,8 @@
 <ul>
     <li ng-show="$ctrl.patientPrograms.length != 0" ng-repeat="patientProgram in $ctrl.patientPrograms | orderBy: '-dateEnrolled'">
         <!-- href="#" included so bootstrap will style this as a link -->
-        <a href="#" ng-click="$ctrl.gotoProgramDashboard($event, patientProgram.program.uuid)">
-            {{ patientProgram.program.display }}
+        <a href="#" ng-click="$ctrl.gotoProgramDashboard($event, patientProgram.program.uuid)" title="{{ patientProgram.program.display }}">
+            {{ patientProgram.program.display | limitTo: 20 }}{{patientProgram.program.display.length > 20 ? '...' : ''}}
         </a>
 
         <div ng-show="!patientProgram.dateCompleted" class="tag">{{ $ctrl.widgetsCommons.formatDate(patientProgram.dateEnrolled,$ctrl.config.JSDateFormat,$ctrl.config.language) }} - {{'coreapps.dashboardwidgets.programs.current' | translate }}</div>


### PR DESCRIPTION
Truncates the program name with ellipses (...) if the program name exceeds 20 characters (adding the full program name as a tooltip to view on hover), to ensure that it does not overflow into the dates.

Example:
![image](https://github.com/openmrs/openmrs-module-coreapps/assets/356297/f00a5951-f718-49cf-bca2-e744204b3790)

