### PR TITLE
SL-734: add new duringCurrentEnrollmentInProgram config parameter to display obs only from the current program enrollment

### DIFF
--- a/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.controller.js
@@ -271,8 +271,10 @@ export default class ObsGraphController {
                     continue;
                   }
                   //if duringCurrentEnrollmentInProgram config parameter is defined, then display only the obs from the current/active program enrollment
-                  if (self.programDateEnrolled && ( (new Date(self.programDateEnrolled)) > new Date(obs.obsDatetime))) {
-                    //the obs was taken prior to the current program enrollment date
+                  if ( (self.duringCurrentEnrollmentInProgram && (self.programDateEnrolled == null)) ||
+                      (self.programDateEnrolled && ( (new Date(self.programDateEnrolled)) > new Date(obs.obsDatetime)))) {
+                    // there is no current open enrollment in the program specified or
+                    // the obs was taken prior to the current program enrollment date
                     continue;
                   }
                   


### PR DESCRIPTION
@mogoodrich , I got this widget working to display obs only from the current program enrollment if the duringCurrentEnrollmentInProgram config parameter is specified:

![Screenshot 2024-09-11 at 4 13 54 PM](https://github.com/user-attachments/assets/ec1744d7-86d2-47aa-afc0-b852034b7478)
