### PR TITLE
SL-734: sequentially chain the REST calls

### DIFF
--- a/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.controller.js
+++ b/omod/src/main/web/dashboardwidgets/obsgraph/obsgraph.controller.js
@@ -297,12 +297,12 @@ export default class ObsGraphController {
       };
 
       this.getConfig();
-
-      const getProgramEnrollmentDatePromise = this.getProgramEnrollmentDate();
-      const getConceptNamesPromise = this.getConceptNames();
-      const getAllObsPromise = this.getAllObs();
-
-      this.$q.all([getProgramEnrollmentDatePromise, getConceptNamesPromise, getAllObsPromise]).then(function(){
+      // chaining the promises sequentially
+      this.getProgramEnrollmentDate().then(function(){
+        return self.getConceptNames();
+      }).then(function() {
+        return self.getAllObs();
+      }).then(function(){
         self.updateChartData();
       });
     }


### PR DESCRIPTION
@mogoodrich , I finally figured out the problem with this widget, and why sometimes it did not show any data. The problem was that all the REST calls were executed asynchronously with no way of controlling the order of those REST calls. Therefore, sometimes the obs REST call was returning before the programenrollment, and the widget was configured to display only obs during a certain program enrollment but we had no enrollment date because the REST call did not return before the obs rest.
So, now I chained those REST calls to execute sequentially, the grapah loads correctly every time:

![Screenshot 2024-10-03 at 10 07 39 AM](https://github.com/user-attachments/assets/843e763b-2875-412e-ba4d-18cc19b7fd57)
