### PR TITLE
UHM-8241: add html classes to widgets

### DIFF
--- a/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/dashboardwidgets/DashboardWidgetFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/coreapps/fragment/controller/dashboardwidgets/DashboardWidgetFragmentController.java
@@ -12,6 +12,7 @@ import org.openmrs.ui.framework.annotation.FragmentParam;
 import org.openmrs.ui.framework.annotation.InjectBeans;
 import org.openmrs.ui.framework.annotation.SpringBean;
 import org.openmrs.ui.framework.fragment.FragmentConfiguration;
+import org.openmrs.ui.framework.fragment.FragmentModel;
 
 import java.io.IOException;
 import java.util.Map;
@@ -19,7 +20,7 @@ import java.util.Map;
 public class DashboardWidgetFragmentController {
 
     public void controller(FragmentConfiguration config, @FragmentParam("app") AppDescriptor app, @InjectBeans PatientDomainWrapper patientWrapper,
-                           @SpringBean("adminService") AdministrationService adminService) throws IOException {
+                           @SpringBean("adminService") AdministrationService adminService, FragmentModel model) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
 
         Object patient = null;
@@ -62,5 +63,6 @@ public class DashboardWidgetFragmentController {
         Map<String, Object> appConfigMap = mapper.convertValue(appConfig, Map.class);
         config.merge(appConfigMap);
         config.addAttribute("json", appConfig.toString().replace('\"', '\''));
+        model.put("app", app);
     }
 }

--- a/omod/src/main/webapp/fragments/clinicianfacing/diagnosisWidget.gsp
+++ b/omod/src/main/webapp/fragments/clinicianfacing/diagnosisWidget.gsp
@@ -1,4 +1,4 @@
-<div id="coreapps-diagnosesList" class="info-section">
+<div id="coreapps-diagnosesList" class="info-section diagnosis-widget">
     <div class="info-header">
         <i class="icon-diagnosis"></i>
         <h3>${ ui.message("coreapps.clinicianfacing.diagnoses").toUpperCase() }</h3>

--- a/omod/src/main/webapp/fragments/clinicianfacing/visitsSection.gsp
+++ b/omod/src/main/webapp/fragments/clinicianfacing/visitsSection.gsp
@@ -1,7 +1,7 @@
 <%
     def patient = config.patient
 %>
-<div class="info-section">
+<div class="info-section visits-section">
     <div class="info-header">
         <i class="icon-calendar"></i>
         <h3>${ ui.message(config.label ? config.label : "coreapps.clinicianfacing.recentVisits").toUpperCase() }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/customLinksWidget.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/customLinksWidget.gsp
@@ -1,4 +1,4 @@
-<div id="coreapps-customLinks" class="info-section">
+<div id="coreapps-customLinks" class="info-section custom-links">
     <div class="info-header">
         <i class="${config.icon}"></i>
         <h3>${ ui.message(config.label).toUpperCase() }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/dashboardWidget.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/dashboardWidget.gsp
@@ -5,7 +5,7 @@
 
     def editIcon = config.editIcon ?: "icon-share-alt"
 %>
-<div id="coreapps-${config.id}" class="info-section openmrs-contrib-dashboardwidgets">
+<div id="coreapps-${config.id}" class="info-section openmrs-contrib-dashboardwidgets ${app.id}">
     <div class="info-header">
         <i class="${config.icon}"></i>
         <h3>${ ui.message(config.label) }</h3>

--- a/omod/src/main/webapp/fragments/patientdashboard/activeDrugOrders.gsp
+++ b/omod/src/main/webapp/fragments/patientdashboard/activeDrugOrders.gsp
@@ -13,7 +13,7 @@
     }
 </style>
 
-<div class="info-section">
+<div class="info-section active-drug-orders">
 
     <div class="info-header">
         <i class="icon-medicine"></i>

--- a/omod/src/main/webapp/fragments/program/programHistory.gsp
+++ b/omod/src/main/webapp/fragments/program/programHistory.gsp
@@ -6,7 +6,7 @@
 
 <% config.programJson.eachWithIndex { json, idx -> %>
 
-    <div id="coreapps-${config.id}-${idx}" class="info-section">
+    <div id="coreapps-${config.id}-${idx}" class="info-section program-history">
         <div class="info-header">
             <i class="${config.icon}"></i>
             <h3>${ ui.message(config.label) }</h3>


### PR DESCRIPTION
Add html class names to various widgets. This makes is easier to select and hide them when embedding the O2 dashboard into an O3 workspace. This PR is similar to [coorespondingn PR](https://github.com/PIH/openmrs-module-pihcore/pull/542) in `openmrs-module-pihcore`.

The work is not exhaustive, but should be good enough for selectors. Unlike the widgets in `module-pihcore`, a lot of these widgets don't have `app` in the Fragment model, so I avoided adding `${app.id}` class to all widgets. 